### PR TITLE
Fix table sort order of variable $orderAsc

### DIFF
--- a/resources/views/components/layouts/table.blade.php
+++ b/resources/views/components/layouts/table.blade.php
@@ -33,7 +33,7 @@
                                 x-bind:class="Object.keys(sortable).length && orderByCol === col
                                 ? (orderAsc || 'rotate-180')
                                 : 'opacity-0'"
-                                name="chevron-down"
+                                name="chevron-up"
                                 class="h-4 w-4 transition-all"
                             />
                         </div>

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -741,7 +741,7 @@ class DataTable extends Component
             $query->orderBy($orderBy, $this->orderAsc ? 'ASC' : 'DESC');
         } else {
             if ($this->orderBy) {
-                $query->orderBy($this->orderBy, $this->orderAsc ? 'DESC' : 'ASC');
+                $query->orderBy($this->orderBy, $this->orderAsc ? 'ASC' : 'DESC');
             } else {
                 $query->orderBy($this->modelKeyName, 'DESC');
             }


### PR DESCRIPTION
Fix $orderAsc variable, because tables have been ordered the wrong way around.