### PR TITLE
Make column labels customizable

### DIFF
--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -64,7 +64,7 @@ class DataTable extends Component
     public array $availableRelations = [];
 
     public array $enabledCols = [];
-    
+
     public array $columnLabels = [];
 
     public array $userFilters = [];

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -64,6 +64,8 @@ class DataTable extends Component
     public array $availableRelations = [];
 
     public array $enabledCols = [];
+    
+    public array $columnLabels = [];
 
     public array $userFilters = [];
 
@@ -332,7 +334,12 @@ class DataTable extends Component
             $value = __(Str::headline($key));
         });
 
-        return $colLabels;
+        $customLabels = $this->columnLabels;
+        array_walk($customLabels, function (&$value) {
+            $value = __(Str::headline($value));
+        });
+
+        return array_merge($colLabels, $customLabels);
     }
 
     public function getIsSearchable(): bool

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -331,15 +331,10 @@ class DataTable extends Component
     {
         $colLabels = array_flip($this->availableCols);
         array_walk($colLabels, function (&$value, $key) {
-            $value = __(Str::headline($key));
+            $value = __(Str::headline($this->columnLabels[$key] ?? $key));
         });
 
-        $customLabels = $this->columnLabels;
-        array_walk($customLabels, function (&$value) {
-            $value = __(Str::headline($value));
-        });
-
-        return array_merge($colLabels, $customLabels);
+        return $colLabels;
     }
 
     public function getIsSearchable(): bool


### PR DESCRIPTION
The new array `$columnLabels` can be used to specify custom labels/names for individual columns. Just add the original column name as the KEY and the custom label als the VALUE.

These will then automatically get 'headlined' and will be translatable as usual.