### PR TITLE
Add view-mode switcher for table/grid layouts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,7 +71,7 @@
 
 ### v2.3 — Views, Kanban, Accessibility & DX
 
-- [ ] View-mode switcher (table/grid/kanban per DataTable)
+- [x] View-mode switcher (table/grid/kanban per DataTable)
 - [ ] Kanban view layout
 - [ ] ARIA attributes & semantic HTML
 - [ ] Keyboard navigation

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -33,6 +33,8 @@ class DataTable extends Component
     use BuildsQueries, Interactions, StoresSettings, SupportsAggregation, SupportsExporting, SupportsGrouping,
         SupportsRelations, SupportsSelecting, SupportsSorting;
 
+    public string $activeLayout = '';
+
     public array $appends = [];
 
     #[Locked]
@@ -286,6 +288,12 @@ class DataTable extends Component
         return array_values(array_unique(array_merge(
             $this->enabledCols, $availableCols, [$this->modelKeyName]
         )));
+    }
+
+    #[Renderless]
+    public function getAvailableLayouts(): array
+    {
+        return $this->availableLayouts();
     }
 
     #[Renderless]
@@ -696,6 +704,19 @@ class DataTable extends Component
     }
 
     #[Renderless]
+    public function setLayout(string $layout): void
+    {
+        if (! in_array($layout, $this->availableLayouts())) {
+            return;
+        }
+
+        $this->activeLayout = $layout;
+        $this->cachedViewData = null;
+        $this->cacheState();
+        $this->loadData();
+    }
+
+    #[Renderless]
     public function setPerPage(int $perPage): void
     {
         if ($perPage <= 0) {
@@ -837,6 +858,11 @@ class DataTable extends Component
      */
     protected function augmentItemArray(array &$itemArray, Model $item): void {}
 
+    protected function availableLayouts(): array
+    {
+        return ['table'];
+    }
+
     protected function compileActions(string $type): array
     {
         if (isset($this->cachedActions[$type])) {
@@ -973,6 +999,14 @@ class DataTable extends Component
 
     protected function getLayout(): string
     {
+        if ($this->activeLayout && in_array($this->activeLayout, $this->availableLayouts())) {
+            return match ($this->activeLayout) {
+                'grid' => 'tall-datatables::layouts.grid',
+                'kanban' => 'tall-datatables::layouts.kanban',
+                default => 'tall-datatables::layouts.table',
+            };
+        }
+
         return 'tall-datatables::layouts.table';
     }
 
@@ -1031,6 +1065,10 @@ class DataTable extends Component
 
     protected function getViewData(): array
     {
+        if ($this->activeLayout === '') {
+            $this->activeLayout = $this->availableLayouts()[0] ?? 'table';
+        }
+
         if ($this->cachedViewData !== null) {
             return $this->cachedViewData;
         }
@@ -1060,6 +1098,8 @@ class DataTable extends Component
             'canSaveDefaultColumns' => $this->canSaveDefaultColumns(),
             'canShareFilters' => $this->canShareFilters(),
             'isSortable' => $this->isSortable(),
+            'availableLayouts' => $this->availableLayouts(),
+            'activeLayout' => $this->activeLayout,
         ];
 
         return $this->cachedViewData;

--- a/src/Traits/DataTables/StoresSettings.php
+++ b/src/Traits/DataTables/StoresSettings.php
@@ -274,6 +274,7 @@ trait StoresSettings
                     'userOrderAsc' => $this->userOrderAsc,
                     'userMultiSort' => $this->userMultiSort,
                     'perPage' => $this->perPage,
+                    'activeLayout' => $this->activeLayout,
                 ],
                 $withEnabledCols ? ['enabledCols' => $this->enabledCols] : []
             ),
@@ -372,6 +373,7 @@ trait StoresSettings
                 'enabledCols' => $this->enabledCols,
                 'aggregatableCols' => $this->aggregatableCols,
                 'perPage' => $this->perPage,
+                'activeLayout' => $this->activeLayout,
             ],
             'is_layout' => true,
         ];

--- a/tests/Feature/ViewModeSwitcherTest.php
+++ b/tests/Feature/ViewModeSwitcherTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use Livewire\Livewire;
+use Tests\Fixtures\Livewire\GridPostDataTable;
+use Tests\Fixtures\Livewire\PostDataTable;
+
+beforeEach(function (): void {
+    $this->user = createTestUser();
+    $this->actingAs($this->user);
+});
+
+describe('View Mode Switcher', function (): void {
+    describe('availableLayouts', function (): void {
+        it('defaults to table only', function (): void {
+            $component = Livewire::test(PostDataTable::class);
+            $layouts = $component->instance()->getAvailableLayouts();
+            expect($layouts)->toBe(['table']);
+        });
+    });
+
+    describe('activeLayout', function (): void {
+        it('defaults to first available layout', function (): void {
+            $component = Livewire::test(PostDataTable::class);
+            expect($component->get('activeLayout'))->toBe('table');
+        });
+
+        it('uses getLayout override when availableLayouts is not overridden', function (): void {
+            $component = Livewire::test(GridPostDataTable::class);
+            $viewData = $component->instance()->getIslandData();
+            expect($viewData['layout'])->toBe('tall-datatables::layouts.grid');
+        });
+    });
+
+    describe('setLayout', function (): void {
+        it('changes the active layout', function (): void {
+            $component = Livewire::test(Tests\Fixtures\Livewire\SwitchablePostDataTable::class)
+                ->call('setLayout', 'grid');
+            expect($component->get('activeLayout'))->toBe('grid');
+        });
+
+        it('rejects invalid layout values', function (): void {
+            $component = Livewire::test(Tests\Fixtures\Livewire\SwitchablePostDataTable::class)
+                ->call('setLayout', 'kanban');
+            expect($component->get('activeLayout'))->toBe('table');
+        });
+
+        it('returns correct layout view name after switching', function (): void {
+            $component = Livewire::test(Tests\Fixtures\Livewire\SwitchablePostDataTable::class)
+                ->call('setLayout', 'grid');
+            $viewData = $component->instance()->getIslandData();
+            expect($viewData['layout'])->toBe('tall-datatables::layouts.grid');
+        });
+    });
+
+    describe('view data', function (): void {
+        it('passes availableLayouts to view', function (): void {
+            $component = Livewire::test(Tests\Fixtures\Livewire\SwitchablePostDataTable::class);
+            $viewData = $component->instance()->getIslandData();
+            expect($viewData['availableLayouts'])->toBe(['table', 'grid']);
+        });
+
+        it('passes activeLayout to view', function (): void {
+            $component = Livewire::test(Tests\Fixtures\Livewire\SwitchablePostDataTable::class);
+            $viewData = $component->instance()->getIslandData();
+            expect($viewData['activeLayout'])->toBe('table');
+        });
+    });
+});

--- a/tests/Feature/ViewModeSwitcherTest.php
+++ b/tests/Feature/ViewModeSwitcherTest.php
@@ -65,4 +65,19 @@ describe('View Mode Switcher', function (): void {
             expect($viewData['activeLayout'])->toBe('table');
         });
     });
+
+    describe('persistence', function (): void {
+        it('includes activeLayout in compiled layout settings', function (): void {
+            $component = Livewire::test(Tests\Fixtures\Livewire\SwitchablePostDataTable::class)
+                ->call('setLayout', 'grid')
+                ->call('loadData');
+
+            $instance = $component->instance();
+
+            $reflection = new ReflectionMethod($instance, 'compileStoredLayout');
+            $layout = $reflection->invoke($instance);
+
+            expect($layout['settings'])->toHaveKey('activeLayout', 'grid');
+        });
+    });
 });

--- a/tests/Fixtures/Livewire/SwitchablePostDataTable.php
+++ b/tests/Fixtures/Livewire/SwitchablePostDataTable.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Fixtures\Livewire;
+
+use Livewire\Attributes\Layout;
+use TeamNiftyGmbH\DataTable\DataTable;
+use Tests\Fixtures\Models\Post;
+
+#[Layout('components.layouts.app')]
+class SwitchablePostDataTable extends DataTable
+{
+    public array $enabledCols = [
+        'title',
+        'content',
+        'is_published',
+    ];
+
+    public bool $isFilterable = true;
+
+    protected string $model = Post::class;
+
+    protected function availableLayouts(): array
+    {
+        return ['table', 'grid'];
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,6 +16,7 @@ use Tests\Fixtures\Livewire\PostDataTable;
 use Tests\Fixtures\Livewire\PostWithCommentsDataTable;
 use Tests\Fixtures\Livewire\PostWithRelationsDataTable;
 use Tests\Fixtures\Livewire\SelectablePostDataTable;
+use Tests\Fixtures\Livewire\SwitchablePostDataTable;
 use Tests\Fixtures\Livewire\UserDataTable;
 
 abstract class TestCase extends BaseTestCase
@@ -41,6 +42,7 @@ abstract class TestCase extends BaseTestCase
         Livewire::component('no-listeners-post-data-table', NoListenersPostDataTable::class);
         Livewire::component('post-with-comments-data-table', PostWithCommentsDataTable::class);
         Livewire::component('custom-tab-post-data-table', CustomTabPostDataTable::class);
+        Livewire::component('switchable-post-data-table', SwitchablePostDataTable::class);
 
         Livewire::component('tall-datatables-options', \TeamNiftyGmbH\DataTable\Livewire\Options::class);
     }


### PR DESCRIPTION
## Summary
- Add `availableLayouts()` method to configure available layouts per DataTable class
- Add `$activeLayout` property with `setLayout()` for runtime switching
- Add icon button group in toolbar (table/grid/kanban icons, only shown when >1 layout)
- Persist `activeLayout` in saved filters and layout cache
- Backward compatible: existing `getLayout()` overrides still work