### PR TITLE
Support != operator for enum/state inline column filters

### DIFF
--- a/resources/views/components/head.blade.php
+++ b/resources/views/components/head.blade.php
@@ -99,7 +99,7 @@
                             $displayValue = $filter['value'] ?? '';
                             $operator = $filter['operator'] ?? '=';
                             // Translate enum/state values
-                            if ($operator === '=' && isset($this->filterValueLists[$filter['column']])) {
+                            if (in_array($operator, ['=', '!=']) && isset($this->filterValueLists[$filter['column']])) {
                                 $label = collect($this->filterValueLists[$filter['column']])->firstWhere('value', $displayValue);
                                 $displayValue = $label['label'] ?? $displayValue;
                             }

--- a/resources/views/components/layouts/table.blade.php
+++ b/resources/views/components/layouts/table.blade.php
@@ -207,6 +207,7 @@
                                                             class="min-w-0 flex-1 border-0 bg-transparent px-3 py-1 text-sm text-gray-600 placeholder-gray-300 outline-none focus:ring-0 dark:text-gray-300 dark:placeholder-gray-600"
                                                             x-bind:placeholder="vi === 0 ? '…' : '{{ __('and') }}…'"
                                                             x-init="$el.value = getTextFilterValue(rowIndex, col, vi)"
+                                                            x-effect="if (document.activeElement !== $el) $el.value = getTextFilterValue(rowIndex, col, vi)"
                                                             x-on:input.debounce.500ms="$wire.setTextFilter(col, $event.target.value, rowIndex, vi)"
                                                         />
                                                         <template x-if="getTextFilterValue(rowIndex, col, vi)">
@@ -234,18 +235,41 @@
                                         </template>
                                         <template x-if="($wire.filterValueLists || {})[col]">
                                             <div
-                                                x-effect="if (!(($wire.textFilters || {})[rowIndex] || {})[col]) { const sel = $el.querySelector('select'); if (sel) sel.value = ''; }"
+                                                x-data="{
+                                                    negated: ((($wire.textFilters || {})[rowIndex] || {})[col] || '').toString().startsWith('!'),
+                                                    getStoredValue() {
+                                                        let v = (($wire.textFilters || {})[rowIndex] || {})[col] || '';
+                                                        return v.toString().startsWith('!') ? v.toString().substring(1) : v.toString();
+                                                    }
+                                                }"
+                                                x-effect="if (!(($wire.textFilters || {})[rowIndex] || {})[col]) { negated = false; const sel = $el.querySelector('select'); if (sel) sel.value = ''; }"
+                                                class="flex items-center"
                                             >
                                                 <select
-                                                    class="w-full border-0 bg-transparent px-3 py-1 text-sm text-gray-600 outline-none focus:ring-0 dark:text-gray-300"
-                                                    x-init="$nextTick(() => $el.value = (($wire.textFilters || {})[rowIndex] || {})[col] || '')"
-                                                    x-on:change="$wire.setTextFilter(col, $event.target.value, rowIndex)"
+                                                    class="min-w-0 flex-1 border-0 bg-transparent px-3 py-1 text-sm text-gray-600 outline-none focus:ring-0 dark:text-gray-300"
+                                                    x-init="$nextTick(() => $el.value = getStoredValue())"
+                                                    x-on:change="$wire.setTextFilter(col, $event.target.value ? (negated ? '!' : '') + $event.target.value : '', rowIndex)"
                                                 >
                                                     <option value=""></option>
                                                     <template x-for="item in ($wire.filterValueLists || {})[col]" x-bind:key="item.value">
                                                         <option x-bind:value="item.value" x-text="item.label"></option>
                                                     </template>
                                                 </select>
+                                                <button
+                                                    type="button"
+                                                    class="shrink-0 cursor-pointer px-1 text-xs font-bold transition-colors"
+                                                    x-bind:class="negated ? 'text-red-500' : 'text-gray-300 hover:text-gray-500 dark:text-gray-600 dark:hover:text-gray-400'"
+                                                    x-on:click="
+                                                        negated = !negated;
+                                                        let sel = $el.parentElement.querySelector('select');
+                                                        if (sel && sel.value) {
+                                                            $wire.setTextFilter(col, (negated ? '!' : '') + sel.value, rowIndex);
+                                                        }
+                                                    "
+                                                    title="{{ __('Negate filter') }}"
+                                                >
+                                                    !=
+                                                </button>
                                             </div>
                                         </template>
                                     </td>

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -419,7 +419,7 @@ class DataTable extends Component
                 $displayValue = $filter['value'] ?? '';
 
                 // Translate enum/state values for display
-                if ($filter['operator'] === '=' && isset($this->filterValueLists[$filter['column']])) {
+                if (in_array($filter['operator'], ['=', '!=']) && isset($this->filterValueLists[$filter['column']])) {
                     $label = collect($this->filterValueLists[$filter['column']])
                         ->firstWhere('value', $displayValue);
                     $displayValue = $label['label'] ?? $displayValue;

--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -992,10 +992,17 @@ trait BuildsQueries
         }
 
         // Columns with value lists (enums, states, booleans) use exact match
+        // Support ! prefix for negation (e.g. "!open" → operator != value "open")
         if (isset($this->filterValueLists[$column])) {
+            $operator = '=';
+            if (str_starts_with($trimmed, '!')) {
+                $operator = '!=';
+                $value = substr($trimmed, 1);
+            }
+
             return [
                 'column' => $column,
-                'operator' => '=',
+                'operator' => $operator,
                 'value' => $value,
             ];
         }

--- a/tests/Browser/FilterUnificationBrowserTest.php
+++ b/tests/Browser/FilterUnificationBrowserTest.php
@@ -168,8 +168,13 @@ describe('Multi-Row Filter Rows', function (): void {
         $page->assertPresent('button[title]');
 
         $result = $page->script('() => {
-            const btn = document.querySelector("button[title]");
-            return btn?.getAttribute("title") ?? null;
+            const buttons = document.querySelectorAll("button[title]");
+            for (const btn of buttons) {
+                if (btn.getAttribute("title").includes("OR")) {
+                    return btn.getAttribute("title");
+                }
+            }
+            return null;
         }');
         $title = is_array($result) && isset($result[0]) ? $result[0] : $result;
 

--- a/tests/Feature/EnumFilterNegationTest.php
+++ b/tests/Feature/EnumFilterNegationTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use Livewire\Livewire;
+use Tests\Fixtures\Livewire\PostDataTable;
+
+beforeEach(function (): void {
+    $this->user = createTestUser();
+    $this->actingAs($this->user);
+});
+
+describe('Enum/state filter negation', function (): void {
+    describe('parseTextFilterValue with valueList columns', function (): void {
+        it('uses = operator for regular valueList values', function (): void {
+            $component = Livewire::test(PostDataTable::class)
+                ->call('loadData');
+
+            // Simulate filterValueLists being populated for is_published (boolean)
+            $instance = $component->instance();
+            $instance->filterValueLists['is_published'] = [
+                ['value' => 1, 'label' => 'Yes'],
+                ['value' => 0, 'label' => 'No'],
+            ];
+
+            $reflection = new ReflectionMethod($instance, 'parseTextFilterValue');
+            $parsed = $reflection->invoke($instance, '1', 'is_published');
+
+            expect($parsed['operator'])->toBe('=')
+                ->and($parsed['value'])->toBe('1');
+        });
+
+        it('uses != operator when valueList value is prefixed with !', function (): void {
+            $component = Livewire::test(PostDataTable::class)
+                ->call('loadData');
+
+            $instance = $component->instance();
+            $instance->filterValueLists['is_published'] = [
+                ['value' => 1, 'label' => 'Yes'],
+                ['value' => 0, 'label' => 'No'],
+            ];
+
+            $reflection = new ReflectionMethod($instance, 'parseTextFilterValue');
+            $parsed = $reflection->invoke($instance, '!1', 'is_published');
+
+            expect($parsed['operator'])->toBe('!=')
+                ->and($parsed['value'])->toBe('1');
+        });
+
+        it('uses != operator for string enum values prefixed with !', function (): void {
+            $component = Livewire::test(PostDataTable::class)
+                ->call('loadData');
+
+            $instance = $component->instance();
+            $instance->filterValueLists['status'] = [
+                ['value' => 'open', 'label' => 'Open'],
+                ['value' => 'closed', 'label' => 'Closed'],
+                ['value' => 'pending', 'label' => 'Pending'],
+            ];
+
+            $reflection = new ReflectionMethod($instance, 'parseTextFilterValue');
+            $parsed = $reflection->invoke($instance, '!open', 'status');
+
+            expect($parsed['operator'])->toBe('!=')
+                ->and($parsed['value'])->toBe('open');
+        });
+    });
+
+    describe('integration with setTextFilter', function (): void {
+        it('applies negated enum filter via setTextFilter', function (): void {
+            createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Published', 'is_published' => true]);
+            createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Draft', 'is_published' => false]);
+
+            $component = Livewire::test(PostDataTable::class)
+                ->call('loadData');
+
+            $instance = $component->instance();
+            $instance->filterValueLists['is_published'] = [
+                ['value' => 1, 'label' => 'Yes'],
+                ['value' => 0, 'label' => 'No'],
+            ];
+
+            // Negate: filter for NOT published (!=1)
+            $component->call('setTextFilter', 'is_published', '!1', 0);
+
+            $data = $component->instance()->getDataForTesting();
+            expect($data['total'])->toBe(1);
+            expect($data['data'][0]['title'])->toBe('Draft');
+        });
+
+        it('applies regular enum filter via setTextFilter', function (): void {
+            createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Published', 'is_published' => true]);
+            createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Draft', 'is_published' => false]);
+
+            $component = Livewire::test(PostDataTable::class)
+                ->call('loadData');
+
+            $instance = $component->instance();
+            $instance->filterValueLists['is_published'] = [
+                ['value' => 1, 'label' => 'Yes'],
+                ['value' => 0, 'label' => 'No'],
+            ];
+
+            // Regular: filter for published (=1)
+            $component->call('setTextFilter', 'is_published', '1', 0);
+
+            $data = $component->instance()->getDataForTesting();
+            expect($data['total'])->toBe(1);
+            expect($data['data'][0]['title'])->toBe('Published');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Inline enum/state dropdown filters in table headers previously only supported `=` (exact match) because `parseTextFilterValue` hardcoded the operator. Now supports `!` prefix for negation (`!=` operator).
- Added a `!=` toggle button next to the inline enum dropdown so users can negate without typing.
- Updated filter badge display (`head.blade.php`, `DataTable.php`) to resolve enum labels for `!=` filters, not just `=`.