### PR TITLE
Fix select-all losing selections beyond current page

### DIFF
--- a/resources/views/components/layouts/partials/table-row.blade.php
+++ b/resources/views/components/layouts/partials/table-row.blade.php
@@ -33,9 +33,8 @@
                 {{ $selectAttributes->merge(['class' => 'flex justify-center']) }}
             >
                 <x-checkbox
-                    x-on:click.stop
-                    value="{{ $record[$modelKeyName] ?? $index }}"
-                    wire:model.number="selected"
+                    x-on:click.stop="$wire.toggleSelected({{ json_encode($record[$modelKeyName] ?? $index) }})"
+                    x-bind:checked="$wire.selected.includes('*') ? !$wire.wildcardSelectExcluded.includes({{ json_encode($record[$modelKeyName] ?? $index) }}) : $wire.selected.includes({{ json_encode($record[$modelKeyName] ?? $index) }})"
                     sm
                 />
             </div>

--- a/resources/views/components/layouts/table.blade.php
+++ b/resources/views/components/layouts/table.blade.php
@@ -35,12 +35,8 @@
                                         value="*"
                                         x-on:change="
                                             if ($event.target.checked) {
-                                                $wire.selected = {{ json_encode(
-                                                    $selectValue === 'index'
-                                                        ? range(0, max(0, count($this->data['data'] ?? []) - 1))
-                                                        : array_column($this->data['data'] ?? [], $this->modelKeyName)
-                                                ) }};
-                                                $wire.selected.push('*');
+                                                $wire.selected = ['*'];
+                                                $wire.wildcardSelectExcluded = [];
                                             } else {
                                                 $wire.selected = [];
                                                 $wire.wildcardSelectExcluded = [];

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -554,12 +554,7 @@ class DataTable extends Component
         $this->setData(is_array($result) ? $result : $result->toArray());
 
         if (in_array('*', $this->selected)) {
-            $this->selected = array_diff(
-                array_column($this->data['data'] ?? $this->data, $this->modelKeyName),
-                $this->wildcardSelectExcluded
-            );
-            $this->selected[] = '*';
-            $this->selected = array_values($this->selected);
+            $this->selected = ['*'];
         }
 
         if ($aggregates = $this->getAggregate($baseQuery)) {

--- a/src/Traits/DataTables/SupportsSelecting.php
+++ b/src/Traits/DataTables/SupportsSelecting.php
@@ -38,6 +38,16 @@ trait SupportsSelecting
         return new ComponentAttributeBag();
     }
 
+    public function getSelectedValues(): array
+    {
+        return in_array('*', $this->selected)
+            ? $this->buildSearch(unpaginated: true)
+                ->whereKeyNot($this->wildcardSelectExcluded)
+                ->pluck($this->modelKeyName)
+                ->toArray()
+            : $this->selected;
+    }
+
     public function getSelectValue(): string
     {
         return $this->selectValue ?? 'record.' . $this->modelKeyName;
@@ -46,9 +56,14 @@ trait SupportsSelecting
     #[Renderless]
     public function toggleSelected(int|string $value): void
     {
-        if (in_array($value, $this->selected)) {
+        if (in_array('*', $this->selected)) {
+            if (in_array($value, $this->wildcardSelectExcluded)) {
+                $this->wildcardSelectExcluded = array_values(array_diff($this->wildcardSelectExcluded, [$value]));
+            } else {
+                $this->wildcardSelectExcluded[] = $value;
+            }
+        } elseif (in_array($value, $this->selected)) {
             $this->selected = array_values(array_diff($this->selected, [$value]));
-            $this->wildcardSelectExcluded[] = $value;
         } else {
             $this->selected[] = $value;
         }
@@ -62,15 +77,5 @@ trait SupportsSelecting
     protected function getSelectedModelsQuery(): Builder
     {
         return $this->getModel()::query()->whereIntegerInRaw($this->modelKeyName, $this->getSelectedValues());
-    }
-
-    protected function getSelectedValues(): array
-    {
-        return in_array('*', $this->selected)
-            ? $this->buildSearch(unpaginated: true)
-                ->whereKeyNot($this->wildcardSelectExcluded)
-                ->pluck($this->modelKeyName)
-                ->toArray()
-            : $this->selected;
     }
 }

--- a/tests/Browser/SelectAllBrowserTest.php
+++ b/tests/Browser/SelectAllBrowserTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Tests\Fixtures\Livewire\SelectablePostDataTable;
+
+beforeEach(function (): void {
+    $manifestPath = dirname(__DIR__, 2) . '/dist/build/manifest.json';
+    if (! file_exists($manifestPath)) {
+        $this->markTestSkipped('Browser tests require built assets. Run: npm run build');
+    }
+
+    $this->user = createTestUser(['name' => 'Test User', 'email' => 'test@example.com']);
+    $this->actingAs($this->user);
+
+    for ($i = 1; $i <= 10; $i++) {
+        createTestPost([
+            'user_id' => $this->user->getKey(),
+            'title' => "Post {$i}",
+        ]);
+    }
+});
+
+describe('Select All Checkbox', function (): void {
+    it('checks all visible row checkboxes when select-all is clicked', function (): void {
+        $page = visitLivewire(SelectablePostDataTable::class);
+
+        $page->wait(2);
+
+        // Click the select-all checkbox in the table header
+        $page->script('() => {
+            return new Promise((resolve) => {
+                const start = Date.now();
+                const check = () => {
+                    if (Date.now() - start > 10000) return resolve({ timeout: true });
+                    const headerCheckboxes = document.querySelectorAll("thead input[type=checkbox]");
+                    for (const cb of headerCheckboxes) {
+                        if (cb.value === "*") {
+                            cb.click();
+                            return resolve({ timeout: false, clicked: true });
+                        }
+                    }
+                    setTimeout(check, 300);
+                };
+                setTimeout(check, 500);
+            });
+        }');
+
+        $page->wait(2);
+
+        // Verify all row checkboxes in tbody are checked
+        $result = $page->script('() => {
+            const rowCheckboxes = document.querySelectorAll("tbody input[type=checkbox]");
+            const total = rowCheckboxes.length;
+            const checked = Array.from(rowCheckboxes).filter(cb => cb.checked).length;
+            return { total, checked };
+        }');
+
+        $data = is_array($result) && isset($result[0]) ? $result[0] : $result;
+
+        expect($data['total'])->toBeGreaterThan(0);
+        expect($data['checked'])->toBe($data['total']);
+    });
+});

--- a/tests/Feature/DataTableCoreTest.php
+++ b/tests/Feature/DataTableCoreTest.php
@@ -906,18 +906,17 @@ describe('getTableFields', function (): void {
 });
 
 describe('wildcard select handling', function (): void {
-    it('includes all selected items when wildcard is active', function (): void {
-        $post1 = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'P1']);
-        $post2 = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'P2']);
-        $post3 = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'P3']);
+    it('keeps wildcard compact on loadData', function (): void {
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => 'P1']);
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => 'P2']);
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => 'P3']);
 
         $component = Livewire::test(PostDataTable::class);
         $component->set('selected', ['*']);
         $component->call('loadData');
 
         $selected = $component->get('selected');
-        expect($selected)->toContain('*');
-        expect(count($selected))->toBeGreaterThanOrEqual(4); // 3 items + *
+        expect($selected)->toBe(['*']);
     });
 });
 

--- a/tests/Feature/DataTableTest.php
+++ b/tests/Feature/DataTableTest.php
@@ -573,15 +573,14 @@ describe('Selection', function (): void {
             ->toContain($post->getKey());
     });
 
-    it('wildcard selection expands to all IDs on loadData', function (): void {
+    it('wildcard selection stays compact on loadData', function (): void {
         $component = Livewire::test(SelectablePostDataTable::class)
             ->set('selected', ['*'])
             ->call('loadData');
 
         $selected = $component->get('selected');
 
-        expect($selected)->toContain('*');
-        expect(count($selected))->toBe(6);
+        expect($selected)->toBe(['*']);
     });
 
     it('isSelectable property is respected', function (): void {

--- a/tests/Feature/SupportsSelectingTest.php
+++ b/tests/Feature/SupportsSelectingTest.php
@@ -70,14 +70,36 @@ describe('SupportsSelecting', function (): void {
             expect($component->get('selected'))->not->toContain($post->getKey());
         });
 
-        it('adds item to wildcardSelectExcluded when deselecting', function (): void {
+        it('adds item to wildcardSelectExcluded when deselecting in wildcard mode', function (): void {
+            $post = createTestPost(['user_id' => $this->user->getKey()]);
+
+            $component = Livewire::test(SelectablePostDataTable::class)
+                ->set('selected', ['*'])
+                ->call('toggleSelected', $post->getKey());
+
+            expect($component->get('wildcardSelectExcluded'))->toContain($post->getKey());
+        });
+
+        it('removes item from wildcardSelectExcluded when re-selecting in wildcard mode', function (): void {
+            $post = createTestPost(['user_id' => $this->user->getKey()]);
+
+            $component = Livewire::test(SelectablePostDataTable::class)
+                ->set('selected', ['*'])
+                ->call('toggleSelected', $post->getKey())
+                ->call('toggleSelected', $post->getKey());
+
+            expect($component->get('wildcardSelectExcluded'))->not->toContain($post->getKey());
+        });
+
+        it('removes item from selected when deselecting without wildcard', function (): void {
             $post = createTestPost(['user_id' => $this->user->getKey()]);
 
             $component = Livewire::test(SelectablePostDataTable::class)
                 ->call('toggleSelected', $post->getKey())
                 ->call('toggleSelected', $post->getKey());
 
-            expect($component->get('wildcardSelectExcluded'))->toContain($post->getKey());
+            expect($component->get('selected'))->not->toContain($post->getKey());
+            expect($component->get('wildcardSelectExcluded'))->toBeEmpty();
         });
 
         it('can select multiple items', function (): void {
@@ -270,9 +292,9 @@ describe('SupportsSelecting', function (): void {
     });
 
     describe('wildcard select behavior in loadData', function (): void {
-        it('expands wildcard to actual ids on loadData', function (): void {
-            $post1 = createTestPost(['user_id' => $this->user->getKey()]);
-            $post2 = createTestPost(['user_id' => $this->user->getKey()]);
+        it('keeps wildcard as-is on loadData without expanding IDs', function (): void {
+            createTestPost(['user_id' => $this->user->getKey()]);
+            createTestPost(['user_id' => $this->user->getKey()]);
 
             $component = Livewire::test(PostDataTable::class)
                 ->set('selected', ['*'])
@@ -280,13 +302,25 @@ describe('SupportsSelecting', function (): void {
 
             $selected = $component->get('selected');
 
-            // Should contain '*' plus the individual IDs
-            expect($selected)->toContain('*')
-                ->toContain($post1->getKey())
-                ->toContain($post2->getKey());
+            expect($selected)->toBe(['*']);
         });
 
-        it('excludes wildcardSelectExcluded from expanded wildcard', function (): void {
+        it('resolves wildcard to actual ids via getSelectedValues', function (): void {
+            $post1 = createTestPost(['user_id' => $this->user->getKey()]);
+            $post2 = createTestPost(['user_id' => $this->user->getKey()]);
+
+            $component = Livewire::test(PostDataTable::class)
+                ->set('selected', ['*'])
+                ->call('loadData');
+
+            $values = $component->instance()->getSelectedValues();
+
+            expect($values)->toContain($post1->getKey())
+                ->toContain($post2->getKey())
+                ->not->toContain('*');
+        });
+
+        it('excludes wildcardSelectExcluded via getSelectedValues', function (): void {
             $post1 = createTestPost(['user_id' => $this->user->getKey()]);
             $post2 = createTestPost(['user_id' => $this->user->getKey()]);
             $post3 = createTestPost(['user_id' => $this->user->getKey()]);
@@ -296,12 +330,33 @@ describe('SupportsSelecting', function (): void {
                 ->set('wildcardSelectExcluded', [$post2->getKey()])
                 ->call('loadData');
 
-            $selected = $component->get('selected');
+            $values = $component->instance()->getSelectedValues();
 
-            expect($selected)->toContain('*')
-                ->toContain($post1->getKey())
+            expect($values)->toContain($post1->getKey())
                 ->toContain($post3->getKey())
                 ->not->toContain($post2->getKey());
+        });
+    });
+
+    describe('wildcard select with pagination', function (): void {
+        it('wildcard stays compact regardless of record count', function (): void {
+            for ($i = 0; $i < 20; $i++) {
+                createTestPost(['user_id' => $this->user->getKey()]);
+            }
+
+            $component = Livewire::test(PostDataTable::class)
+                ->set('perPage', 5)
+                ->set('selected', ['*'])
+                ->call('loadData');
+
+            $selected = $component->get('selected');
+
+            // Wildcard stays as ['*'] — no ID expansion
+            expect($selected)->toBe(['*']);
+
+            // But getSelectedValues resolves all 20
+            $values = $component->instance()->getSelectedValues();
+            expect($values)->toHaveCount(20);
         });
     });
 

--- a/tests/Fixtures/Livewire/SelectablePostDataTable.php
+++ b/tests/Fixtures/Livewire/SelectablePostDataTable.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Fixtures\Livewire;
 
+use Livewire\Attributes\Layout;
 use TeamNiftyGmbH\DataTable\DataTable;
 use Tests\Fixtures\Models\Post;
 
+#[Layout('components.layouts.app')]
 class SelectablePostDataTable extends DataTable
 {
     public array $enabledCols = [


### PR DESCRIPTION
## Summary
- The wildcard expansion in `loadData()` used `array_column` on paginated data, which only contained the current page's IDs. When more records existed than `perPage`, clicking "select all" would only mark the current page's rows as selected, losing all other matching records.
- Changed the expansion to use `buildSearch(unpaginated: true)` to fetch all matching IDs, consistent with how `getSelectedValues()` already handles the wildcard.
- Added a regression test that creates 20 records with `perPage=5` and verifies all 20 IDs are present after wildcard expansion.