### PR TITLE
Extend README and clean up roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Tall DataTables
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/team-nifty-gmbh/tall-datatables.svg?style=flat-square)](https://packagist.org/packages/team-nifty-gmbh/tall-datatables)
-[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/Team-Nifty-GmbH/tall-datatables/tests.yml?branch=2.x&label=tests&style=flat-square)](https://github.com/Team-Nifty-GmbH/tall-datatables/actions?query=workflow%3ATests+branch%3A2.x)
+[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/Team-Nifty-GmbH/tall-datatables/tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/Team-Nifty-GmbH/tall-datatables/actions?query=workflow%3ATests+branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/team-nifty-gmbh/tall-datatables.svg?style=flat-square)](https://packagist.org/packages/team-nifty-gmbh/tall-datatables)
 
 Performant, feature-rich datatables for the TALL stack. Built on Livewire 4 Islands architecture with Alpine.js driven rendering for minimal payloads.
@@ -37,10 +37,6 @@ php artisan migrate
 
 ## Quick Start
 
-```bash
-php artisan make:data-table UserDataTable "App\Models\User"
-```
-
 ```php
 class UserDataTable extends DataTable
 {
@@ -56,20 +52,245 @@ class UserDataTable extends DataTable
 
 ## Layouts
 
-Two built-in layouts: table (default) and grid.
+Three built-in layouts: **table** (default), **grid**, and **kanban**.
+
+### View-Mode Switcher
+
+Let users switch between layouts at runtime:
 
 ```php
-protected function getLayout(): string
+protected function availableLayouts(): array
 {
-    return 'tall-datatables::layouts.grid';
+    return ['table', 'grid', 'kanban'];
+}
+```
+
+When more than one layout is configured, a switcher appears in the toolbar. The active layout is persisted in saved filters.
+
+### Grid Layout
+
+Cards in a responsive CSS grid. Image columns get hero treatment.
+
+```php
+protected function availableLayouts(): array
+{
+    return ['table', 'grid'];
+}
+```
+
+### Kanban Layout
+
+Cards grouped into lanes by a column value. Drag & drop between lanes.
+
+```php
+protected function availableLayouts(): array
+{
+    return ['table', 'kanban'];
+}
+
+// Which column determines the lanes
+protected function kanbanColumn(): string
+{
+    return 'state';
+}
+
+// Optional: explicit lane config (order, labels, colors)
+protected function kanbanLanes(): ?array
+{
+    return [
+        'open' => ['label' => 'Open', 'color' => 'emerald'],
+        'in_progress' => ['label' => 'In Progress', 'color' => 'amber'],
+        'done' => ['label' => 'Done', 'color' => 'indigo'],
+    ];
+}
+
+// Handle drag & drop
+public function kanbanMoveItem(int|string $id, string $targetLane): void
+{
+    MyModel::findOrFail($id)->update(['state' => $targetLane]);
+}
+
+// Optional: custom card blade view
+protected function kanbanCardView(): ?string
+{
+    return 'components.my-kanban-card';
+}
+```
+
+If `kanbanLanes()` returns `null`, lanes are auto-generated from the column's enum/state values.
+
+## Filtering
+
+### Sidebar Filters
+
+Enable filtering with the sidebar:
+
+```php
+public bool $isFilterable = true;
+```
+
+Available operators: `=`, `!=`, `>`, `>=`, `<`, `<=`, `like`, `not like`, `starts with`, `ends with`, `contains`, `does not contain`, `in`, `not in`, `is null`, `is not null`, `between`.
+
+The `in` and `not in` operators accept comma-separated values.
+
+### Date Presets
+
+Date columns automatically show a preset dropdown: Today, Yesterday, This Week/Month/Quarter/Year, Last 7/30 Days, Last Week/Month/Quarter/Year. A "Custom" option opens inline fields for building custom relative date calculations.
+
+### Saved Filters
+
+Users can save their current filter/column/sort configuration and reload it later. Supports shared filters across team members:
+
+```php
+protected function canShareFilters(): bool
+{
+    return true;
+}
+```
+
+## Sorting
+
+Click a column header to sort. Shift+Click for multi-sort on additional columns.
+
+```php
+// Restrict sortable columns (default: all)
+public array $sortable = ['name', 'created_at'];
+```
+
+## Selection
+
+```php
+public bool $isSelectable = true;
+```
+
+Select individual rows or use "select all" (wildcard). The wildcard stays compact (`['*']`) regardless of record count. Use `getSelectedValues()` or `getSelectedModels()` in your actions to resolve the actual records.
+
+## Relation Columns
+
+Display columns from related models using dot notation:
+
+```php
+public array $enabledCols = [
+    'name',
+    'email',
+    'department.name',
+    'department.manager.email',
+];
+```
+
+### Relation Count Columns
+
+Show relation counts by adding `_count` suffix in the column configuration. Counts are filterable and sortable:
+
+```php
+public array $enabledCols = ['name', 'orders_count', 'comments_count'];
+```
+
+## Export
+
+Export data in three formats: Excel (.xlsx), CSV, and JSON. Users select the format from a dropdown in the export tab.
+
+```php
+// Disable export (enabled by default)
+public bool $isExportable = false;
+```
+
+CSV uses semicolon delimiter with UTF-8 BOM for Excel compatibility. JSON exports relations as nested objects.
+
+## Row Actions
+
+Define actions using `DataTableButton`:
+
+```php
+protected function getRowActions(): array
+{
+    return [
+        DataTableButton::make('edit')
+            ->label(__('Edit'))
+            ->icon('pencil')
+            ->wireClick('edit(record.id)'),
+    ];
+}
+```
+
+## Row Drag & Drop
+
+Enable manual row reordering:
+
+```php
+protected function getRowDragDropConfig(): ?array
+{
+    return [
+        'column' => 'sort_order',
+    ];
+}
+```
+
+## Custom Formatters
+
+Register formatters for custom display logic:
+
+```php
+use TeamNiftyGmbH\DataTable\Formatters\FormatterRegistry;
+
+app(FormatterRegistry::class)->register(MyCast::class, new MyFormatter());
+```
+
+Built-in formatters: `boolean`, `date`, `datetime`, `money`, `percentage`, `image`, `link`, `badge`, `float`, `string`, `array`.
+
+### Custom Column Transformation
+
+Use `augmentItemArray()` to add computed columns before formatters are applied:
+
+```php
+protected function augmentItemArray(array &$itemArray, Model $item): void
+{
+    $itemArray['full_name'] = $item->first_name . ' ' . $item->last_name;
+}
+```
+
+## Sidebar Tabs
+
+Extend the sidebar with custom tabs:
+
+```php
+public function getSidebarTabs(): array
+{
+    $tabs = parent::getSidebarTabs();
+
+    $tabs[] = [
+        'id' => 'my-tab',
+        'label' => __('My Tab'),
+        'view' => 'components.my-custom-tab',
+    ];
+
+    return $tabs;
+}
+```
+
+## Positive Empty State
+
+Show a friendly message when a table is expected to be empty:
+
+```php
+public bool $positiveEmptyState = true;
+```
+
+## Default Columns
+
+Allow users to save their column layout as the default:
+
+```php
+protected function canSaveDefaultColumns(): bool
+{
+    return true;
 }
 ```
 
 ## Testing
 
 ```bash
-cd packages/tall-datatables
-vendor/bin/testbench package:test
+vendor/bin/pest
 ```
 
 ## Credits

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,59 +1,8 @@
 # Roadmap
 
-## Themes
+## Completed
 
-### User Personalization
-
-- **Shared / Published Saved Filters** — Allow users to share their saved filter presets with the team or make them publicly available for all users of a DataTable.
-- **User-controlled Default Columns** — Let users define which columns are visible by default when they open a DataTable, persisted per user.
-- **Row Drag & Drop (opt-in)** — Optional drag & drop support for manual row reordering (e.g. updating a `sort_order` field). Column drag & drop already exists.
-
-### UX
-
-- **Positive Empty State (opt-in)** — Show a happy emoji instead of the sad one when a table is empty. Some tables are expected to be empty (e.g. error logs, open issues) and an empty state should feel like a good thing.
-- **Multi-Sort** — Sort by multiple columns simultaneously via Shift+Click on additional column headers.
-- **Saved Views (opt-in)** — Save the complete table state (filters, columns, sorting, layout) as a named view. Opt-in per DataTable to allow users to create and switch between saved views.
-
-### Filter System
-
-- **Extended Filter Operators** — Add `in`, `not in`, `starts with`, `contains` operators and support for custom operator callbacks.
-- **Relative Date Filters** — Predefined date ranges like "Last 30 days", "This month", "This quarter", "Last year".
-- **Configurable Date Format** — Make the date parsing format configurable instead of the hardcoded `dd.mm.yyyy`.
-
-### Layouts
-
-- **Kanban View** — A Kanban board layout as a third option alongside table and grid. Cards grouped by a configurable status/category column with drag & drop between lanes.
-
-### Export
-
-- **CSV Export** — Lightweight export without the Excel dependency.
-- **JSON Export** — Structured export for BI tools and API integrations.
-- **Streaming Export** — Chunked/streaming export for large datasets (100k+ rows) to avoid memory issues.
-
-### Accessibility
-
-- **ARIA Attributes** — Semantic HTML with `aria-sort`, `role` attributes and proper table structure.
-- **Keyboard Navigation** — Arrow key and tab navigation through cells and rows.
-
-### Aggregation
-
-- **Relation Count Columns** — Add `withCount` based columns for relations (e.g. "Orders Count" for a contact). Displayed as a regular column with filter input in the header. Filtering on count columns uses HAVING clauses.
-
-### Extensibility
-
-- **Action Builder DSL** — A fluent API for defining row, table and bulk actions instead of raw arrays.
-- **Sidebar Tabs Documentation** — Document the existing `getSidebarTabs()` extensibility hook with examples.
-- **Formatter Plugin Documentation** — Document the `FormatterRegistry` and how to register custom formatters.
-
-### Documentation
-
-- **Extended README** — Cover advanced filtering, custom formatters, actions, performance tuning and customization patterns.
-
----
-
-## Releases
-
-### v2.1 — User Personalization ✓
+### v2.1 — User Personalization
 
 - [x] Shared / published saved filters
 - [x] User-controlled default columns
@@ -62,24 +11,29 @@
 - [x] Multi-sort
 - [x] Relation count columns
 
-### v2.2 — Filters & Export ✓
+### v2.2 — Filters & Export
 
-- [x] Extended filter operators (`in`, `not in`, `starts with`, `contains`)
-- [x] Relative date filters
-- [x] CSV export
-- [x] JSON export
+- [x] Extended filter operators (`in`, `not in`, `starts with`, `contains`, `does not contain`, `ends with`)
+- [x] Relative date filter presets (Today, This Week, Last 30 Days, etc.)
+- [x] CSV export (semicolon delimiter, UTF-8 BOM)
+- [x] JSON export (nested relation objects)
 
-### v2.3 — Views, Kanban, Accessibility & DX
+### v2.3 — Views & Kanban
 
 - [x] View-mode switcher (table/grid/kanban per DataTable)
-- [x] Kanban view layout
-- [ ] ARIA attributes & semantic HTML
-- [ ] Keyboard navigation
-- [ ] Action builder DSL
-- [ ] Sidebar tabs & formatter plugin documentation
-- [ ] Extended README
+- [x] Kanban view layout with configurable lanes and drag & drop
+- [x] Extended README
+
+---
+
+## Planned
+
+### v2.4 — Accessibility
+
+- [ ] ARIA attributes (`aria-sort`, `role`, `aria-selected`)
+- [ ] Keyboard navigation (arrow keys, tab)
 
 ### Future
 
 - [ ] Configurable date format (breaking: changes default parsing behavior)
-- [ ] Streaming export for large datasets
+- [ ] Streaming export for large datasets (100k+ rows)


### PR DESCRIPTION
## Summary
- Expand README with documentation for all v2.x features: layouts, kanban, filtering, date presets, exports, selection, relation columns, formatters, sidebar tabs, and more
- Clean up roadmap: mark v2.3 done, remove completed items from "Action Builder DSL" (already exists as DataTableButton), restructure remaining items into v2.4