### PR TITLE
Guard bccomp/Number::trim against non-numeric values

### DIFF
--- a/src/Casts/BcFloat.php
+++ b/src/Casts/BcFloat.php
@@ -28,7 +28,7 @@ class BcFloat implements CastsAttributes, HasFrontendFormatter
             return $model->getAttributeValue($key);
         }
 
-        $value = Number::trim($value ?? 0);
+        $value = Number::trim(is_numeric($value) ? $value : 0);
 
         return bccomp((string) fmod($value, 1), '0', 10) === 0
             // not a decimal number, pad with 2 decimal places

--- a/src/Casts/Money.php
+++ b/src/Casts/Money.php
@@ -28,7 +28,7 @@ class Money implements CastsAttributes, HasFrontendFormatter
             return $model->getAttributeValue($key);
         }
 
-        $value = Number::trim($value ?? 0);
+        $value = Number::trim(is_numeric($value) ? $value : 0);
 
         return bccomp((string) fmod($value, 1), '0', 10) === 0
             // not a decimal number, pad with 2 decimal places

--- a/src/Formatters/MoneyFormatter.php
+++ b/src/Formatters/MoneyFormatter.php
@@ -11,7 +11,7 @@ class MoneyFormatter implements Formatter
 
     public function format(mixed $value, array $context = []): string
     {
-        if (is_null($value)) {
+        if (! is_numeric($value)) {
             return '';
         }
 

--- a/tests/Unit/Casts/BcFloatTest.php
+++ b/tests/Unit/Casts/BcFloatTest.php
@@ -195,6 +195,26 @@ describe('BcFloat Cast Direct Methods', function (): void {
         expect(BcFloat::getFrontendFormatter('arg1', 'arg2'))->toBe('float');
     });
 
+    test('handles empty string without throwing ValueError', function (): void {
+        $cast = new BcFloat();
+        $model = new Product();
+        $model->setRawAttributes(['quantity' => '']);
+
+        $result = $cast->get($model, 'quantity', '', ['quantity' => '']);
+
+        expect($result)->toBe(0.00)->toBeFloat();
+    });
+
+    test('handles non-numeric string without throwing ValueError', function (): void {
+        $cast = new BcFloat();
+        $model = new Product();
+        $model->setRawAttributes(['quantity' => 'abc']);
+
+        $result = $cast->get($model, 'quantity', 'abc', ['quantity' => 'abc']);
+
+        expect($result)->toBe(0.00)->toBeFloat();
+    });
+
     test('delegates to attribute mutator when model has one', function (): void {
         $cast = new BcFloat();
 

--- a/tests/Unit/Casts/MoneyTest.php
+++ b/tests/Unit/Casts/MoneyTest.php
@@ -216,4 +216,24 @@ describe('Money Cast Direct Methods', function (): void {
 
         expect($result)->toBe(100.0);
     });
+
+    it('handles empty string without throwing ValueError', function (): void {
+        $cast = new Money();
+        $model = new Product();
+        $model->setRawAttributes(['price' => '']);
+
+        $result = $cast->get($model, 'price', '', ['price' => '']);
+
+        expect($result)->toBe(0.00)->toBeFloat();
+    });
+
+    it('handles non-numeric string without throwing ValueError', function (): void {
+        $cast = new Money();
+        $model = new Product();
+        $model->setRawAttributes(['price' => 'abc']);
+
+        $result = $cast->get($model, 'price', 'abc', ['price' => 'abc']);
+
+        expect($result)->toBe(0.00)->toBeFloat();
+    });
 });

--- a/tests/Unit/Formatters/MoneyFormatterTest.php
+++ b/tests/Unit/Formatters/MoneyFormatterTest.php
@@ -9,6 +9,18 @@ describe('MoneyFormatter', function (): void {
         expect($formatter->format(null))->toBe('');
     });
 
+    it('returns empty string for empty string', function (): void {
+        $formatter = new MoneyFormatter();
+
+        expect($formatter->format(''))->toBe('');
+    });
+
+    it('returns empty string for non-numeric string', function (): void {
+        $formatter = new MoneyFormatter();
+
+        expect($formatter->format('abc'))->toBe('');
+    });
+
     it('formats a basic monetary value', function (): void {
         $formatter = new MoneyFormatter();
         $result = $formatter->format(100.00);


### PR DESCRIPTION
## Summary
- Replace `$value ?? 0` with `is_numeric($value) ? $value : 0` in Money and BcFloat casts to handle empty strings and non-numeric values that cause `TypeError` in `Number::trim()` and `ValueError` in `bccomp()`
- Replace `is_null()` with `!is_numeric()` in MoneyFormatter for the same reason
- Add tests for empty string and non-numeric string edge cases

Fixes Flare error #8592464