### PR TITLE
Replace fmod with bcmod to fix bccomp ValueError

### DIFF
--- a/src/Casts/BcFloat.php
+++ b/src/Casts/BcFloat.php
@@ -3,7 +3,6 @@
 namespace TeamNiftyGmbH\DataTable\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
-use Illuminate\Support\Number;
 use TeamNiftyGmbH\DataTable\Contracts\HasFrontendFormatter;
 
 class BcFloat implements CastsAttributes, HasFrontendFormatter
@@ -28,13 +27,11 @@ class BcFloat implements CastsAttributes, HasFrontendFormatter
             return $model->getAttributeValue($key);
         }
 
-        $value = Number::trim(is_numeric($value) ? $value : 0);
+        $value = is_numeric($value) ? (string) $value : '0';
 
-        return bccomp((string) fmod($value, 1), '0', 10) === 0
-            // not a decimal number, pad with 2 decimal places
-            ? round($value, 2)
-            // a decimal number, return as is
-            : $value;
+        return bccomp(bcmod($value, '1', 10), '0', 10) === 0
+            ? round((float) $value, 2)
+            : (float) $value;
     }
 
     /**

--- a/src/Casts/Money.php
+++ b/src/Casts/Money.php
@@ -3,7 +3,6 @@
 namespace TeamNiftyGmbH\DataTable\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
-use Illuminate\Support\Number;
 use TeamNiftyGmbH\DataTable\Contracts\HasFrontendFormatter;
 
 class Money implements CastsAttributes, HasFrontendFormatter
@@ -28,13 +27,11 @@ class Money implements CastsAttributes, HasFrontendFormatter
             return $model->getAttributeValue($key);
         }
 
-        $value = Number::trim(is_numeric($value) ? $value : 0);
+        $value = is_numeric($value) ? (string) $value : '0';
 
-        return bccomp((string) fmod($value, 1), '0', 10) === 0
-            // not a decimal number, pad with 2 decimal places
-            ? round($value, 2)
-            // a decimal number, return as is
-            : $value;
+        return bccomp(bcmod($value, '1', 10), '0', 10) === 0
+            ? round((float) $value, 2)
+            : (float) $value;
     }
 
     /**

--- a/tests/Unit/Casts/BcFloatTest.php
+++ b/tests/Unit/Casts/BcFloatTest.php
@@ -215,6 +215,17 @@ describe('BcFloat Cast Direct Methods', function (): void {
         expect($result)->toBe(0.00)->toBeFloat();
     });
 
+    test('handles decimal string with tiny fractional artifact without throwing', function (): void {
+        $cast = new BcFloat();
+        $model = new Product();
+
+        $model->setRawAttributes(['quantity' => '95.0000000940']);
+
+        $result = $cast->get($model, 'quantity', '95.0000000940', ['quantity' => '95.0000000940']);
+
+        expect($result)->toBeFloat();
+    });
+
     test('delegates to attribute mutator when model has one', function (): void {
         $cast = new BcFloat();
 

--- a/tests/Unit/Casts/MoneyTest.php
+++ b/tests/Unit/Casts/MoneyTest.php
@@ -236,4 +236,16 @@ describe('Money Cast Direct Methods', function (): void {
 
         expect($result)->toBe(0.00)->toBeFloat();
     });
+
+    it('handles decimal string with tiny fractional artifact without throwing', function (): void {
+        $cast = new Money();
+        $model = new Product();
+
+        // DB decimal value where fmod would produce scientific notation like 9.4E-8
+        $model->setRawAttributes(['price' => '95.0000000940']);
+
+        $result = $cast->get($model, 'price', '95.0000000940', ['price' => '95.0000000940']);
+
+        expect($result)->toBeFloat();
+    });
 });


### PR DESCRIPTION
## Summary
- Replace `fmod()`/`Number::trim()` with `bcmod()` in Money and BcFloat casts to stay in bcmath string-land
- `fmod()` produces scientific notation (e.g. `9.4E-8`) for values like `95.0000000940` which `bccomp()` rejects as not well-formed
- `Number::trim()` forces float conversion, causing the same issue
- Also guards against non-numeric input values (empty strings, etc.)

Fixes Flare error #8592464