### PR TITLE
Fix progress bar rendering for decimal values

### DIFF
--- a/src/Formatters/FormatterRegistry.php
+++ b/src/Formatters/FormatterRegistry.php
@@ -93,7 +93,7 @@ class FormatterRegistry
             'money' => new MoneyFormatter(),
             'coloredmoney' => new MoneyFormatter(colored: true),
             'percentage' => new PercentageFormatter(),
-            'progresspercentage' => new PercentageFormatter(progressBar: true),
+            'progresspercentage' => new PercentageFormatter(progressBar: true, multiplier: 100),
             'coloredfloat' => new FloatFormatter(colored: true),
             'state', 'badge' => new BadgeFormatter(),
             'email' => new LinkFormatter(type: 'email'),

--- a/src/Formatters/PercentageFormatter.php
+++ b/src/Formatters/PercentageFormatter.php
@@ -6,7 +6,10 @@ use TeamNiftyGmbH\DataTable\Formatters\Contracts\Formatter;
 
 class PercentageFormatter implements Formatter
 {
-    public function __construct(public readonly bool $progressBar = false) {}
+    public function __construct(
+        public readonly bool $progressBar = false,
+        public readonly float $multiplier = 1,
+    ) {}
 
     public function format(mixed $value, array $context = []): string
     {
@@ -14,7 +17,7 @@ class PercentageFormatter implements Formatter
             return '';
         }
 
-        $floatValue = (float) $value;
+        $floatValue = (float) bcmul((string) $value, (string) $this->multiplier, 10);
 
         if (! $this->progressBar) {
             $decimals = fmod($floatValue, 1) === 0.0 ? 0 : 2;

--- a/tests/Unit/Formatters/PercentageFormatterTest.php
+++ b/tests/Unit/Formatters/PercentageFormatterTest.php
@@ -70,4 +70,28 @@ describe('PercentageFormatter', function (): void {
 
         expect($result)->toContain('width: 100.00%');
     });
+
+    it('renders progress bar with multiplier for decimal 1.0 as 100%', function (): void {
+        $formatter = new PercentageFormatter(progressBar: true, multiplier: 100);
+
+        expect($formatter->format(1.0))->toContain('width: 100.00%');
+    });
+
+    it('renders progress bar with multiplier for decimal 0.5 as 50%', function (): void {
+        $formatter = new PercentageFormatter(progressBar: true, multiplier: 100);
+
+        expect($formatter->format(0.5))->toContain('width: 50.00%');
+    });
+
+    it('renders text percentage with multiplier for decimal 0.75', function (): void {
+        $formatter = new PercentageFormatter(multiplier: 100);
+
+        expect($formatter->format(0.75))->toBe('75 %');
+    });
+
+    it('renders progress bar with multiplier clamped to 100%', function (): void {
+        $formatter = new PercentageFormatter(progressBar: true, multiplier: 100);
+
+        expect($formatter->format(1.5))->toContain('width: 100.00%');
+    });
 });


### PR DESCRIPTION
## Summary
- Progress values (0.0-1.0) were rendered as 0-1% width instead of 0-100%
- Added `multiplier` parameter to `PercentageFormatter` (default 1, uses bcmul)
- `progresspercentage` formatter now uses `multiplier: 100`
- Existing `percentage` formatter behavior unchanged