### PR TITLE
Add element formatter support to ArrayFormatter

### DIFF
--- a/src/Formatters/ArrayFormatter.php
+++ b/src/Formatters/ArrayFormatter.php
@@ -6,6 +6,10 @@ use TeamNiftyGmbH\DataTable\Formatters\Contracts\Formatter;
 
 class ArrayFormatter implements Formatter
 {
+    public function __construct(
+        protected ?Formatter $elementFormatter = null,
+    ) {}
+
     public function format(mixed $value, array $context = []): string
     {
         if (is_null($value)) {
@@ -30,8 +34,14 @@ class ArrayFormatter implements Formatter
 
         if ($isFlat) {
             return implode(' ', array_map(
-                fn (mixed $item) => '<span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-200">'
-                    . e((string) $item) . '</span>',
+                function (mixed $item) use ($context): string {
+                    $display = $this->elementFormatter
+                        ? $this->elementFormatter->format($item, $context)
+                        : e((string) $item);
+
+                    return '<span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-200">'
+                        . $display . '</span>';
+                },
                 $value
             ));
         }

--- a/src/Formatters/FormatterRegistry.php
+++ b/src/Formatters/FormatterRegistry.php
@@ -75,6 +75,14 @@ class FormatterRegistry
             return new BadgeFormatter(mapping: $mapping);
         }
 
+        if ($name === 'array' && ($elementFormatterKey = data_get($options, 'elementFormatter'))) {
+            $elementFormatter = is_string($elementFormatterKey)
+                ? $this->resolve($elementFormatterKey)
+                : null;
+
+            return new ArrayFormatter(elementFormatter: $elementFormatter);
+        }
+
         return $this->resolve($castClass);
     }
 

--- a/src/Traits/DataTables/SupportsRelations.php
+++ b/src/Traits/DataTables/SupportsRelations.php
@@ -427,7 +427,9 @@ trait SupportsRelations
                 }
 
                 if ($isManyRelation) {
-                    $relatedFormatters[$enabledCol] = 'array';
+                    $relatedFormatters[$enabledCol] = $attributeInfo->formatter
+                        ? ['array', ['elementFormatter' => $attributeInfo->formatter]]
+                        : 'array';
                 } elseif ($attributeInfo->formatter) {
                     $relatedFormatters[$enabledCol] = $attributeInfo->formatter;
                 }

--- a/tests/Feature/SupportsRelationsTest.php
+++ b/tests/Feature/SupportsRelationsTest.php
@@ -895,9 +895,10 @@ describe('SupportsRelations', function (): void {
 
             $formatters = $result[5];
 
-            // comments.body is a HasMany relation column, should get 'array' formatter
+            // comments.body is a HasMany relation column, should get array formatter with element formatter
             expect($formatters)->toHaveKey('comments.body');
-            expect($formatters['comments.body'])->toBe('array');
+            expect($formatters['comments.body'])->toBeArray()
+                ->and($formatters['comments.body'][0])->toBe('array');
         });
     });
 
@@ -990,9 +991,10 @@ describe('SupportsRelations', function (): void {
 
             $relatedFormatters = $result[5];
 
-            // comments.body is a HasMany relation column, should have 'array' formatter
+            // comments.body is a HasMany relation column, should have array formatter with element formatter
             expect($relatedFormatters)->toHaveKey('comments.body');
-            expect($relatedFormatters['comments.body'])->toBe('array');
+            expect($relatedFormatters['comments.body'])->toBeArray()
+                ->and($relatedFormatters['comments.body'][0])->toBe('array');
         });
 
         it('excludes HasMany columns from sortable', function (): void {
@@ -1168,7 +1170,8 @@ describe('constructWith with HasMany columns', function (): void {
         $relatedFormatters = $result[5];
 
         expect($relatedFormatters)->toHaveKey('comments.body')
-            ->and($relatedFormatters['comments.body'])->toBe('array');
+            ->and($relatedFormatters['comments.body'])->toBeArray()
+            ->and($relatedFormatters['comments.body'][0])->toBe('array');
     });
 
     it('excludes HasMany relation columns from sortable', function (): void {

--- a/tests/Unit/Formatters/ArrayFormatterTest.php
+++ b/tests/Unit/Formatters/ArrayFormatterTest.php
@@ -119,4 +119,38 @@ describe('ArrayFormatter', function (): void {
 
         expect($formatter->format([null, null]))->toBe('');
     });
+
+    it('applies element formatter to each value', function (): void {
+        $percentageFormatter = new TeamNiftyGmbH\DataTable\Formatters\PercentageFormatter();
+        $formatter = new ArrayFormatter(elementFormatter: $percentageFormatter);
+
+        $result = $formatter->format([42, 85]);
+
+        expect($result)
+            ->toContain('rounded-full')
+            ->toContain('>42 %</span>')
+            ->toContain('>85 %</span>');
+    });
+
+    it('element formatter with null values are filtered', function (): void {
+        $percentageFormatter = new TeamNiftyGmbH\DataTable\Formatters\PercentageFormatter();
+        $formatter = new ArrayFormatter(elementFormatter: $percentageFormatter);
+
+        $result = $formatter->format([42, null, 85]);
+
+        expect($result)
+            ->toContain('>42 %</span>')
+            ->toContain('>85 %</span>')
+            ->not->toContain('>null</span>');
+    });
+
+    it('without element formatter renders raw values in badges', function (): void {
+        $formatter = new ArrayFormatter();
+
+        $result = $formatter->format(['2025-03-17', '2026-04-21']);
+
+        expect($result)
+            ->toContain('>2025-03-17</span>')
+            ->toContain('>2026-04-21</span>');
+    });
 });


### PR DESCRIPTION
## Summary
- HasMany/MorphMany relation columns now apply the element's formatter (date, float, etc.) to each value before rendering as badge
- `constructWith()` passes the element type from `SchemaInfo` to the ArrayFormatter via options
- `FormatterRegistry::resolveWithOptions()` resolves the element formatter and injects it into ArrayFormatter
- Dates in array columns now display formatted instead of raw `2025-03-17`