### PR TITLE
Fix filter inputs not clearing on Clear All button

### DIFF
--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -230,6 +230,11 @@ class DataTable extends Component
         $this->groupBy = null;
         $this->loadedFilterId = null;
         $this->startSearch();
+
+        $this->js(<<<'JS'
+            $el.querySelectorAll("thead input[type=search]").forEach(i => i.value = "");
+            $el.querySelectorAll("thead select").forEach(s => s.value = "");
+        JS);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Filter inputs (search + select) in thead were not visually cleared when clicking "Clear" button
- `x-effect` reactivity doesn't fire reliably when island caching skips DOM re-rendering
- Added explicit `$this->js()` call to clear all inputs and selects after resetting server state