### PR TITLE
Restore v1 behavior: don't strip computed columns from enabledCols

### DIFF
--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -430,6 +430,11 @@ trait BuildsQueries
         return $result;
     }
 
+    protected function getRequiredCols(): array
+    {
+        return [];
+    }
+
     protected function getReturnKeys(): array
     {
         return array_filter(array_merge(

--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -273,6 +273,11 @@ trait BuildsQueries
         return $paginator;
     }
 
+    protected function getRequiredCols(): array
+    {
+        return [];
+    }
+
     /**
      * Build the formatter map once, then reuse for all rows.
      */
@@ -428,11 +433,6 @@ trait BuildsQueries
         $result->setCollection($mapped);
 
         return $result;
-    }
-
-    protected function getRequiredCols(): array
-    {
-        return [];
     }
 
     protected function getReturnKeys(): array

--- a/src/Traits/DataTables/SupportsRelations.php
+++ b/src/Traits/DataTables/SupportsRelations.php
@@ -311,12 +311,6 @@ trait SupportsRelations
         $relatedFormatters = [];
         $this->withCountRelations = [];
 
-        foreach ($this->getRequiredCols() as $requiredCol) {
-            if (! in_array($requiredCol, $this->enabledCols)) {
-                array_unshift($this->enabledCols, $requiredCol);
-            }
-        }
-
         foreach (array_merge($this->enabledCols, $this->getReturnKeys()) as $enabledCol) {
             // Handle _count columns: e.g. 'posts_count' → withCount('posts')
             if (str_ends_with($enabledCol, '_count')) {
@@ -396,14 +390,6 @@ trait SupportsRelations
             }
 
             $attributeInfo = $modelInfo->attribute($fieldName);
-
-            if (is_null($attributeInfo)) {
-                if (! in_array($enabledCol, $this->getRequiredCols())) {
-                    $this->enabledCols = array_values(array_diff($this->enabledCols, [$enabledCol]));
-                }
-
-                continue;
-            }
 
             $isManyRelation = $relationInstance instanceof HasMany
                 || $relationInstance instanceof HasManyThrough

--- a/src/Traits/DataTables/SupportsRelations.php
+++ b/src/Traits/DataTables/SupportsRelations.php
@@ -311,6 +311,12 @@ trait SupportsRelations
         $relatedFormatters = [];
         $this->withCountRelations = [];
 
+        foreach ($this->getRequiredCols() as $requiredCol) {
+            if (! in_array($requiredCol, $this->enabledCols)) {
+                array_unshift($this->enabledCols, $requiredCol);
+            }
+        }
+
         foreach (array_merge($this->enabledCols, $this->getReturnKeys()) as $enabledCol) {
             // Handle _count columns: e.g. 'posts_count' → withCount('posts')
             if (str_ends_with($enabledCol, '_count')) {
@@ -392,7 +398,9 @@ trait SupportsRelations
             $attributeInfo = $modelInfo->attribute($fieldName);
 
             if (is_null($attributeInfo)) {
-                $this->enabledCols = array_values(array_diff($this->enabledCols, [$enabledCol]));
+                if (! in_array($enabledCol, $this->getRequiredCols())) {
+                    $this->enabledCols = array_values(array_diff($this->enabledCols, [$enabledCol]));
+                }
 
                 continue;
             }

--- a/tests/Feature/SupportsRelationsTest.php
+++ b/tests/Feature/SupportsRelationsTest.php
@@ -1325,20 +1325,19 @@ describe('getFilterValueList', function (): void {
 });
 
 describe('constructWith null attributeInfo', function (): void {
-    it('skips non-existent columns without causing SELECT * fallback', function (): void {
+    it('treats unknown columns as virtual without stripping them', function (): void {
         $component = Livewire::test(PostWithRelationsDataTable::class);
         $instance = $component->instance();
 
-        // Add a column that does not exist on the model
-        $instance->enabledCols = array_merge($instance->enabledCols, ['nonexistent_column']);
+        // Add a column that does not exist on the model (computed/virtual)
+        $instance->enabledCols = array_merge($instance->enabledCols, ['computed_column']);
 
-        // constructWith is called via getFilterableColumns - should skip unknown columns cleanly
         $filterable = $instance->getFilterableColumns();
 
-        expect($filterable)->toBeArray();
-        expect($filterable)->not->toContain('nonexistent_column');
+        // Virtual columns are not filterable
+        expect($filterable)->not->toContain('computed_column');
 
-        // The non-existent column should have been removed from enabledCols
-        expect($instance->enabledCols)->not->toContain('nonexistent_column');
+        // But they stay in enabledCols (v1 behavior — computed columns are kept)
+        expect($instance->enabledCols)->toContain('computed_column');
     });
 });


### PR DESCRIPTION
## Summary
- v2 added a check that removed columns from `enabledCols` when SchemaInfo didn't recognize them
- This broke computed columns like `avatar`, `url`, `product_image` that are added via `augmentItemArray`
- v1 treated unknown columns as virtual (triggering SELECT *) without stripping them
- Restored that behavior — no more stripping, no `getRequiredCols()` needed