### PR TITLE
Add EnumFormatter for automatic enum value translation

### DIFF
--- a/src/Formatters/EnumFormatter.php
+++ b/src/Formatters/EnumFormatter.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace TeamNiftyGmbH\DataTable\Formatters;
+
+use Illuminate\Support\Str;
+use TeamNiftyGmbH\DataTable\Formatters\Contracts\Formatter;
+
+class EnumFormatter implements Formatter
+{
+    public function __construct(
+        protected ?string $enumClass = null,
+    ) {}
+
+    public function format(mixed $value, array $context = []): string
+    {
+        if (is_null($value)) {
+            return '';
+        }
+
+        if ($this->enumClass && enum_exists($this->enumClass)) {
+            $enum = $this->enumClass::tryFrom($value);
+
+            if ($enum) {
+                return e(__(Str::headline($enum->name)));
+            }
+        }
+
+        return e(__(Str::headline((string) $value)));
+    }
+}

--- a/src/Formatters/FormatterRegistry.php
+++ b/src/Formatters/FormatterRegistry.php
@@ -9,6 +9,15 @@ class FormatterRegistry
     /** @var array<string, Formatter> */
     protected array $registry = [];
 
+    public function isEnum(string $class): bool
+    {
+        if (enum_exists($class)) {
+            return true;
+        }
+
+        return class_exists($class) && method_exists($class, 'tryFrom') && method_exists($class, 'cases');
+    }
+
     public function register(string $castClass, Formatter $formatter): static
     {
         $this->registry[$castClass] = $formatter;
@@ -116,14 +125,5 @@ class FormatterRegistry
             'enum' => new EnumFormatter(),
             default => $this->isEnum($castClass) ? new EnumFormatter($castClass) : new StringFormatter(),
         };
-    }
-
-    public function isEnum(string $class): bool
-    {
-        if (enum_exists($class)) {
-            return true;
-        }
-
-        return class_exists($class) && method_exists($class, 'tryFrom') && method_exists($class, 'cases');
     }
 }

--- a/src/Formatters/FormatterRegistry.php
+++ b/src/Formatters/FormatterRegistry.php
@@ -29,6 +29,10 @@ class FormatterRegistry
                 return $this->registry[$baseName];
             }
 
+            if ($this->isEnum($castClass)) {
+                return new EnumFormatter($castClass);
+            }
+
             return $this->autoDetect($baseName);
         }
 
@@ -109,7 +113,17 @@ class FormatterRegistry
             'url', 'link' => new LinkFormatter(),
             'relativetime' => new DateFormatter(mode: 'relative'),
             'time' => new DateFormatter(mode: 'time'),
-            default => new StringFormatter(),
+            'enum' => new EnumFormatter(),
+            default => $this->isEnum($castClass) ? new EnumFormatter($castClass) : new StringFormatter(),
         };
+    }
+
+    public function isEnum(string $class): bool
+    {
+        if (enum_exists($class)) {
+            return true;
+        }
+
+        return class_exists($class) && method_exists($class, 'tryFrom') && method_exists($class, 'cases');
     }
 }

--- a/src/Traits/DataTables/SupportsRelations.php
+++ b/src/Traits/DataTables/SupportsRelations.php
@@ -18,10 +18,10 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\Renderless;
-use ReflectionClass;
 use ReflectionException;
 use ReflectionMethod;
 use Spatie\ModelStates\State;
+use TeamNiftyGmbH\DataTable\Formatters\FormatterRegistry;
 use TeamNiftyGmbH\DataTable\Helpers\SchemaInfo;
 use TeamNiftyGmbH\DataTable\ModelInfo\Attribute;
 use Throwable;
@@ -424,6 +424,8 @@ trait SupportsRelations
                     $relatedFormatters[$enabledCol] = $attributeInfo->formatter
                         ? ['array', ['elementFormatter' => $attributeInfo->formatter]]
                         : 'array';
+                } elseif ($attributeInfo->cast && app(FormatterRegistry::class)->isEnum($attributeInfo->cast)) {
+                    $relatedFormatters[$enabledCol] = $attributeInfo->cast;
                 } elseif ($attributeInfo->formatter) {
                     $relatedFormatters[$enabledCol] = $attributeInfo->formatter;
                 }
@@ -497,15 +499,11 @@ trait SupportsRelations
             return;
         }
 
-        $castReflection = new ReflectionClass($attributeInfo->cast);
-
-        if ($castReflection->isEnum()) {
-            $this->filterValueLists[$enabledCol] = array_map(function ($enum) {
-                return [
-                    'value' => $enum->value,
-                    'label' => __(Str::headline($enum->name)),
-                ];
-            }, $attributeInfo->cast::cases());
+        if (app(FormatterRegistry::class)->isEnum($attributeInfo->cast)) {
+            $this->filterValueLists[$enabledCol] = array_map(fn ($enum) => [
+                'value' => $enum->value,
+                'label' => __(Str::headline($enum->name)),
+            ], $attributeInfo->cast::cases());
         }
     }
 

--- a/tests/Unit/Formatters/EnumFormatterTest.php
+++ b/tests/Unit/Formatters/EnumFormatterTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use TeamNiftyGmbH\DataTable\Formatters\EnumFormatter;
+use TeamNiftyGmbH\DataTable\Formatters\FormatterRegistry;
+
+enum TestStatusEnum: string
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+    case PendingReview = 'pending_review';
+}
+
+describe('EnumFormatter', function (): void {
+    it('returns empty string for null', function (): void {
+        $formatter = new EnumFormatter();
+
+        expect($formatter->format(null))->toBe('');
+    });
+
+    it('translates value using Str::headline without enum class', function (): void {
+        $formatter = new EnumFormatter();
+
+        expect($formatter->format('pending_review'))->toBe('Pending Review');
+    });
+
+    it('translates value using enum name when enum class is provided', function (): void {
+        $formatter = new EnumFormatter(TestStatusEnum::class);
+
+        expect($formatter->format('pending_review'))->toBe('Pending Review');
+    });
+
+    it('uses enum case name not backing value for translation', function (): void {
+        $formatter = new EnumFormatter(TestStatusEnum::class);
+
+        // TestStatusEnum::Active->name = 'Active', Str::headline('Active') = 'Active'
+        expect($formatter->format('active'))->toBe('Active');
+    });
+
+    it('escapes HTML entities', function (): void {
+        $formatter = new EnumFormatter();
+
+        expect($formatter->format('<b>bold</b>'))->toBe('&lt;B&gt;Bold&lt;/B&gt;');
+    });
+
+    it('falls back to Str::headline for unknown enum value', function (): void {
+        $formatter = new EnumFormatter(TestStatusEnum::class);
+
+        expect($formatter->format('unknown_value'))->toBe('Unknown Value');
+    });
+});
+
+describe('FormatterRegistry enum detection', function (): void {
+    it('resolves native PHP enum to EnumFormatter', function (): void {
+        $registry = new FormatterRegistry();
+
+        expect($registry->resolve(TestStatusEnum::class))->toBeInstanceOf(EnumFormatter::class);
+    });
+
+    it('resolves enum string to EnumFormatter via autoDetect', function (): void {
+        $registry = new FormatterRegistry();
+
+        expect($registry->resolve('enum'))->toBeInstanceOf(EnumFormatter::class);
+    });
+
+    it('isEnum returns true for native PHP enum', function (): void {
+        $registry = new FormatterRegistry();
+
+        expect($registry->isEnum(TestStatusEnum::class))->toBeTrue();
+    });
+
+    it('isEnum returns false for regular class', function (): void {
+        $registry = new FormatterRegistry();
+
+        expect($registry->isEnum(FormatterRegistry::class))->toBeFalse();
+    });
+
+    it('isEnum returns true for class with tryFrom and cases methods', function (): void {
+        $fakeEnum = new class()
+        {
+            public static function tryFrom(int|string|null $value): ?object
+            {
+                return null;
+            }
+
+            public static function cases(): array
+            {
+                return [];
+            }
+        };
+
+        $registry = new FormatterRegistry();
+
+        expect($registry->isEnum($fakeEnum::class))->toBeTrue();
+    });
+});

--- a/tests/Unit/Formatters/EnumFormatterTest.php
+++ b/tests/Unit/Formatters/EnumFormatterTest.php
@@ -77,14 +77,14 @@ describe('FormatterRegistry enum detection', function (): void {
     it('isEnum returns true for class with tryFrom and cases methods', function (): void {
         $fakeEnum = new class()
         {
-            public static function tryFrom(int|string|null $value): ?object
-            {
-                return null;
-            }
-
             public static function cases(): array
             {
                 return [];
+            }
+
+            public static function tryFrom(int|string|null $value): ?object
+            {
+                return null;
             }
         };
 


### PR DESCRIPTION
## Summary
- Add EnumFormatter that translates enum values using case name + Str::headline + __()
- Auto-detect native PHP enums and FluxEnum classes via isEnum() in FormatterRegistry
- Store enum FQCN in constructWith instead of v1 lowercased basename, so resolve() can detect enums
- Support enum filter dropdowns for FluxEnum classes (not just native PHP enums)