### PR TITLE
Add formatted values toggle to DataTable export

### DIFF
--- a/resources/js/components/datatable-options.js
+++ b/resources/js/components/datatable-options.js
@@ -36,6 +36,7 @@ export default function datatable_options(wire) {
         },
         exportColumns: [],
         exportFormat: 'xlsx',
+        exportFormatted: true,
         relationTableFields: {},
         filterSelectType: 'text',
         filterIndex: 0,

--- a/resources/views/components/options/tabs/export.blade.php
+++ b/resources/views/components/options/tabs/export.blade.php
@@ -9,6 +9,10 @@
     </div>
 @endforeach
 <div class="pt-3 border-t border-gray-200 dark:border-secondary-700 flex flex-col gap-3">
+    <x-toggle
+        x-model="exportFormatted"
+        :label="__('Formatted values')"
+    />
     <x-select.native
         x-model="exportFormat"
         :label="__('Format')"
@@ -20,7 +24,7 @@
     />
     <x-button
         loading
-        x-on:click="$wire.export(exportColumns, exportFormat); $tsui.close.slide('data-table-sidebar-' + $wire.id.toLowerCase());"
+        x-on:click="$wire.export(exportColumns, exportFormat, exportFormatted); $tsui.close.slide('data-table-sidebar-' + $wire.id.toLowerCase());"
         color="indigo"
         class="w-full"
         :text="__('Export')"

--- a/src/Exports/Concerns/ExportsData.php
+++ b/src/Exports/Concerns/ExportsData.php
@@ -3,10 +3,13 @@
 namespace TeamNiftyGmbH\DataTable\Exports\Concerns;
 
 use Illuminate\Support\Str;
+use TeamNiftyGmbH\DataTable\Formatters\BooleanFormatter;
 
 trait ExportsData
 {
     protected array $exportColumns = [];
+
+    protected array $exportFormatters = [];
 
     public function headings(): array
     {
@@ -42,6 +45,16 @@ trait ExportsData
 
                 if (is_array($value)) {
                     $value = implode('; ', array_filter($value));
+                }
+            }
+
+            if (! is_null($value) && isset($this->exportFormatters[$column])) {
+                $formatter = $this->exportFormatters[$column];
+
+                if ($formatter instanceof BooleanFormatter) {
+                    $value = $value ? __('Yes') : __('No');
+                } else {
+                    $value = strip_tags($formatter->format($value, $rowArray));
                 }
             }
 

--- a/src/Exports/CsvExport.php
+++ b/src/Exports/CsvExport.php
@@ -13,8 +13,10 @@ class CsvExport
     public function __construct(
         private EloquentBuilder $builder,
         array $exportColumns = [],
+        array $formatters = [],
     ) {
         $this->exportColumns = $exportColumns;
+        $this->exportFormatters = $formatters;
     }
 
     public function download(string $filename): StreamedResponse

--- a/src/Exports/DataTableExport.php
+++ b/src/Exports/DataTableExport.php
@@ -18,10 +18,11 @@ class DataTableExport implements FromQuery, ShouldAutoSize, WithHeadings, WithMa
 
     private EloquentBuilder $builder;
 
-    public function __construct(EloquentBuilder $builder, array $exportColumns = [])
+    public function __construct(EloquentBuilder $builder, array $exportColumns = [], array $formatters = [])
     {
         $this->builder = $builder;
         $this->exportColumns = $exportColumns;
+        $this->exportFormatters = $formatters;
     }
 
     public function map($row): array

--- a/src/Exports/JsonExport.php
+++ b/src/Exports/JsonExport.php
@@ -13,8 +13,10 @@ class JsonExport
     public function __construct(
         private EloquentBuilder $builder,
         array $exportColumns = [],
+        array $formatters = [],
     ) {
         $this->exportColumns = $exportColumns;
+        $this->exportFormatters = $formatters;
     }
 
     public function download(string $filename): StreamedResponse

--- a/src/Traits/DataTables/SupportsExporting.php
+++ b/src/Traits/DataTables/SupportsExporting.php
@@ -2,6 +2,7 @@
 
 namespace TeamNiftyGmbH\DataTable\Traits\DataTables;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Response;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\Renderless;
@@ -10,6 +11,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 use TeamNiftyGmbH\DataTable\Exports\CsvExport;
 use TeamNiftyGmbH\DataTable\Exports\DataTableExport;
 use TeamNiftyGmbH\DataTable\Exports\JsonExport;
+use TeamNiftyGmbH\DataTable\Formatters\FormatterRegistry;
 
 trait SupportsExporting
 {
@@ -22,16 +24,22 @@ trait SupportsExporting
     public bool $isExportable = true;
 
     #[Renderless]
-    public function export(array $columns = [], string $format = 'xlsx'): Response|BinaryFileResponse|StreamedResponse
+    public function export(array $columns = [], string $format = 'xlsx', bool $formatted = true): Response|BinaryFileResponse|StreamedResponse
     {
         $query = $this->buildSearch();
         $columns = array_filter($columns);
         $basename = class_basename($this->getModel()) . '_' . now()->toDateTimeLocalString('minute');
 
+        $formatters = [];
+        if ($formatted) {
+            $model = app($this->getModel());
+            $formatters = $this->resolveExportFormatters($model, $columns);
+        }
+
         return match ($format) {
-            'csv' => (new CsvExport($query, $columns))->download($basename . '.csv'),
-            'json' => (new JsonExport($query, $columns))->download($basename . '.json'),
-            default => (new DataTableExport($query, $columns))->download($basename . '.xlsx'),
+            'csv' => (new CsvExport($query, $columns, $formatters))->download($basename . '.csv'),
+            'json' => (new JsonExport($query, $columns, $formatters))->download($basename . '.json'),
+            default => (new DataTableExport($query, $columns, $formatters))->download($basename . '.xlsx'),
         };
     }
 
@@ -39,5 +47,40 @@ trait SupportsExporting
     public function getExportableColumns(): array
     {
         return array_unique(array_merge($this->availableCols, $this->enabledCols));
+    }
+
+    protected function resolveExportFormatters(Model $model, array $columns): array
+    {
+        $registry = app(FormatterRegistry::class);
+        $customFormatters = $this->getFormatters();
+        $modelCasts = $model->getCasts();
+        $formatters = [];
+
+        foreach ($columns as $col) {
+            $baseCol = str_contains($col, '.') ? last(explode('.', $col)) : $col;
+
+            if (isset($customFormatters[$col]) && is_string($customFormatters[$col])) {
+                $formatters[$col] = $registry->resolve($customFormatters[$col]);
+            } elseif (isset($customFormatters[$col]) && is_array($customFormatters[$col])) {
+                $formatterName = $customFormatters[$col][0] ?? 'string';
+                $formatterOptions = $customFormatters[$col][1] ?? [];
+                $formatters[$col] = $registry->resolveWithOptions($formatterName, $formatterOptions);
+            } else {
+                $casts = str_contains($col, '.')
+                    ? $this->resolveCastsForColumn($model, $col)
+                    : $modelCasts;
+
+                $castValue = $casts[$baseCol] ?? null;
+
+                if (is_array($castValue) && count($castValue) >= 1) {
+                    $formatters[$col] = $registry->resolveWithOptions($castValue[0] ?? 'string', $castValue[1] ?? []);
+                } else {
+                    $stringCasts = array_filter($casts, 'is_string');
+                    $formatters[$col] = $registry->resolveForColumn($baseCol, $stringCasts);
+                }
+            }
+        }
+
+        return $formatters;
     }
 }

--- a/tests/Feature/SupportsExportingTest.php
+++ b/tests/Feature/SupportsExportingTest.php
@@ -184,6 +184,24 @@ describe('SupportsExporting', function (): void {
 
             expect($response->headers->get('content-disposition'))->toContain('.xlsx');
         });
+
+        it('accepts formatted parameter', function (): void {
+            createTestPost(['user_id' => $this->user->getKey(), 'is_published' => true]);
+
+            $component = Livewire::test(PostDataTable::class)->call('loadData');
+            $response = $component->instance()->export(['title', 'is_published'], 'csv', true);
+
+            expect($response)->toBeInstanceOf(Symfony\Component\HttpFoundation\StreamedResponse::class);
+        });
+
+        it('exports raw values when formatted is false', function (): void {
+            createTestPost(['user_id' => $this->user->getKey(), 'is_published' => true]);
+
+            $component = Livewire::test(PostDataTable::class)->call('loadData');
+            $response = $component->instance()->export(['title', 'is_published'], 'csv', false);
+
+            expect($response)->toBeInstanceOf(Symfony\Component\HttpFoundation\StreamedResponse::class);
+        });
     });
 
     describe('isExportable in view data', function (): void {

--- a/tests/Unit/Exports/ExportsDataFormattedTest.php
+++ b/tests/Unit/Exports/ExportsDataFormattedTest.php
@@ -4,7 +4,6 @@ use Illuminate\Database\Eloquent\Model;
 use TeamNiftyGmbH\DataTable\Exports\Concerns\ExportsData;
 use TeamNiftyGmbH\DataTable\Formatters\BooleanFormatter;
 use TeamNiftyGmbH\DataTable\Formatters\Contracts\Formatter;
-use TeamNiftyGmbH\DataTable\Formatters\StringFormatter;
 
 class StubFormatter implements Formatter
 {

--- a/tests/Unit/Exports/ExportsDataFormattedTest.php
+++ b/tests/Unit/Exports/ExportsDataFormattedTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model;
+use TeamNiftyGmbH\DataTable\Exports\Concerns\ExportsData;
+use TeamNiftyGmbH\DataTable\Formatters\BooleanFormatter;
+use TeamNiftyGmbH\DataTable\Formatters\Contracts\Formatter;
+use TeamNiftyGmbH\DataTable\Formatters\StringFormatter;
+
+class StubFormatter implements Formatter
+{
+    public function format(mixed $value, array $context = []): string
+    {
+        return '<span class="badge">' . e($value) . '</span>';
+    }
+}
+
+class ExportsDataTestClass
+{
+    use ExportsData;
+
+    public function __construct(array $columns, array $formatters = [])
+    {
+        $this->exportColumns = $columns;
+        $this->exportFormatters = $formatters;
+    }
+
+    public function testMapRow($row): array
+    {
+        return $this->mapRow($row);
+    }
+}
+
+describe('ExportsData formatted export', function (): void {
+    test('mapRow returns raw values when no formatters set', function (): void {
+        $exporter = new ExportsDataTestClass(['title', 'status']);
+
+        $row = new class() extends Model
+        {
+            protected $guarded = [];
+
+            public function __construct()
+            {
+                parent::__construct(['title' => 'Test', 'status' => 'active']);
+            }
+        };
+
+        $result = $exporter->testMapRow($row);
+
+        expect($result)->toBe(['title' => 'Test', 'status' => 'active']);
+    });
+
+    test('mapRow applies formatters and strips HTML when formatters set', function (): void {
+        $exporter = new ExportsDataTestClass(
+            ['title', 'status'],
+            ['status' => new StubFormatter()]
+        );
+
+        $row = new class() extends Model
+        {
+            protected $guarded = [];
+
+            public function __construct()
+            {
+                parent::__construct(['title' => 'Test', 'status' => 'active']);
+            }
+        };
+
+        $result = $exporter->testMapRow($row);
+
+        expect($result['status'])->toBe('active');
+        expect($result['title'])->toBe('Test');
+    });
+
+    test('mapRow converts boolean SVG to Yes/No text', function (): void {
+        $exporter = new ExportsDataTestClass(
+            ['is_active'],
+            ['is_active' => new BooleanFormatter()]
+        );
+
+        $trueRow = new class() extends Model
+        {
+            protected $guarded = [];
+
+            public function __construct()
+            {
+                parent::__construct(['is_active' => true]);
+            }
+        };
+
+        $falseRow = new class() extends Model
+        {
+            protected $guarded = [];
+
+            public function __construct()
+            {
+                parent::__construct(['is_active' => false]);
+            }
+        };
+
+        expect($exporter->testMapRow($trueRow)['is_active'])->toBe(__('Yes'));
+        expect($exporter->testMapRow($falseRow)['is_active'])->toBe(__('No'));
+    });
+
+    test('mapRow handles null values with formatters', function (): void {
+        $exporter = new ExportsDataTestClass(
+            ['status'],
+            ['status' => new StubFormatter()]
+        );
+
+        $row = new class() extends Model
+        {
+            protected $guarded = [];
+
+            public function __construct()
+            {
+                parent::__construct(['status' => null]);
+            }
+        };
+
+        expect($exporter->testMapRow($row)['status'])->toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- Add toggle in export tab to switch between raw DB values and formatted/translated values
- When enabled: apply same formatters used in table display, strip HTML for clean export
- BooleanFormatter SVG icons converted to Yes/No text
- Toggle defaults to on (formatted)