### PR TITLE
Add resizable DataTable columns (opt-in)

### DIFF
--- a/config/tall-datatables.php
+++ b/config/tall-datatables.php
@@ -43,4 +43,6 @@ return [
     'models' => [
         'datatable_user_setting' => TeamNiftyGmbH\DataTable\Models\DatatableUserSetting::class,
     ],
+
+    'resizable_columns' => false,
 ];

--- a/config/tall-datatables.php
+++ b/config/tall-datatables.php
@@ -44,5 +44,5 @@ return [
         'datatable_user_setting' => TeamNiftyGmbH\DataTable\Models\DatatableUserSetting::class,
     ],
 
-    'resizable_columns' => false,
+    'resizable_columns' => env('TALL_DATATABLES_RESIZABLE_COLUMNS', false),
 ];

--- a/config/tall-datatables.php
+++ b/config/tall-datatables.php
@@ -43,6 +43,4 @@ return [
     'models' => [
         'datatable_user_setting' => TeamNiftyGmbH\DataTable\Models\DatatableUserSetting::class,
     ],
-
-    'resizable_columns' => env('TALL_DATATABLES_RESIZABLE_COLUMNS', false),
 ];

--- a/resources/js/components/data-table.js
+++ b/resources/js/components/data-table.js
@@ -3,6 +3,7 @@ export default function data_table() {
         stickyCols: [],
         showSelectedActions: false,
         _echoChannels: [],
+        _resizing: null,
 
         init() {
             this.stickyCols = this.$wire.stickyCols || [];
@@ -75,6 +76,58 @@ export default function data_table() {
             }
             this.stickyCols = cols;
             this.$wire.stickyCols = cols;
+        },
+
+        startResize(event, col) {
+            event.preventDefault();
+            event.stopPropagation();
+
+            let th = event.target.closest('th');
+            let startX = event.clientX;
+            let startWidth = th.offsetWidth;
+            let table = th.closest('table');
+
+            table.classList.remove('table-auto');
+            table.classList.add('table-fixed');
+
+            let onMouseMove = (e) => {
+                let newWidth = Math.max(50, startWidth + (e.clientX - startX));
+                th.style.width = newWidth + 'px';
+            };
+
+            let onMouseUp = () => {
+                document.removeEventListener('mousemove', onMouseMove);
+                document.removeEventListener('mouseup', onMouseUp);
+                document.body.style.cursor = '';
+                document.body.style.userSelect = '';
+
+                this._persistColWidths(table);
+            };
+
+            document.body.style.cursor = 'col-resize';
+            document.body.style.userSelect = 'none';
+            document.addEventListener('mousemove', onMouseMove);
+            document.addEventListener('mouseup', onMouseUp);
+        },
+
+        _persistColWidths(table) {
+            let colWidths = {};
+            let cols = this.$wire.enabledCols || [];
+            let ths = table.querySelectorAll('thead > tr:first-child > th');
+
+            // Skip first th (checkbox/spacer column)
+            let offset = 1;
+            cols.forEach((col, i) => {
+                let th = ths[i + offset];
+                if (th && th.style.width) {
+                    colWidths[col] = parseInt(th.style.width, 10);
+                }
+            });
+
+            if (Object.keys(colWidths).length > 0) {
+                this.$wire.colWidths = colWidths;
+                this.$wire.storeColWidths(colWidths);
+            }
         },
     };
 }

--- a/resources/js/components/data-table.js
+++ b/resources/js/components/data-table.js
@@ -3,7 +3,6 @@ export default function data_table() {
         stickyCols: [],
         showSelectedActions: false,
         _echoChannels: [],
-        _resizing: null,
 
         init() {
             this.stickyCols = this.$wire.stickyCols || [];
@@ -78,56 +77,5 @@ export default function data_table() {
             this.$wire.stickyCols = cols;
         },
 
-        startResize(event, col) {
-            event.preventDefault();
-            event.stopPropagation();
-
-            let th = event.target.closest('th');
-            let startX = event.clientX;
-            let startWidth = th.offsetWidth;
-            let table = th.closest('table');
-
-            table.classList.remove('table-auto');
-            table.classList.add('table-fixed');
-
-            let onMouseMove = (e) => {
-                let newWidth = Math.max(50, startWidth + (e.clientX - startX));
-                th.style.width = newWidth + 'px';
-            };
-
-            let onMouseUp = () => {
-                document.removeEventListener('mousemove', onMouseMove);
-                document.removeEventListener('mouseup', onMouseUp);
-                document.body.style.cursor = '';
-                document.body.style.userSelect = '';
-
-                this._persistColWidths(table);
-            };
-
-            document.body.style.cursor = 'col-resize';
-            document.body.style.userSelect = 'none';
-            document.addEventListener('mousemove', onMouseMove);
-            document.addEventListener('mouseup', onMouseUp);
-        },
-
-        _persistColWidths(table) {
-            let colWidths = {};
-            let cols = this.$wire.enabledCols || [];
-            let ths = table.querySelectorAll('thead > tr:first-child > th');
-
-            // Skip first th (checkbox/spacer column)
-            let offset = 1;
-            cols.forEach((col, i) => {
-                let th = ths[i + offset];
-                if (th && th.style.width) {
-                    colWidths[col] = parseInt(th.style.width, 10);
-                }
-            });
-
-            if (Object.keys(colWidths).length > 0) {
-                this.$wire.colWidths = colWidths;
-                this.$wire.storeColWidths(colWidths);
-            }
-        },
     };
 }

--- a/resources/views/components/data-table-wrapper.blade.php
+++ b/resources/views/components/data-table-wrapper.blade.php
@@ -45,6 +45,51 @@
             if (Array.isArray(val)) return val[valueIndex] || '';
             return valueIndex === 0 ? (val || '') : '';
         },
+        startResize(event, col) {
+            event.preventDefault();
+            event.stopPropagation();
+
+            let th = event.target.closest('th');
+            let startX = event.clientX;
+            let startWidth = th.offsetWidth;
+            let table = th.closest('table');
+
+            table.classList.remove('table-auto');
+            table.classList.add('table-fixed');
+
+            let onMouseMove = (e) => {
+                let newWidth = Math.max(50, startWidth + (e.clientX - startX));
+                th.style.width = newWidth + 'px';
+            };
+
+            let onMouseUp = () => {
+                document.removeEventListener('mousemove', onMouseMove);
+                document.removeEventListener('mouseup', onMouseUp);
+                document.body.style.cursor = '';
+                document.body.style.userSelect = '';
+
+                let colWidths = {};
+                let cols = $wire.enabledCols || [];
+                let ths = table.querySelectorAll('thead > tr:first-child > th');
+                let offset = 1;
+                cols.forEach((c, i) => {
+                    let t = ths[i + offset];
+                    if (t && t.style.width) {
+                        colWidths[c] = parseInt(t.style.width, 10);
+                    }
+                });
+
+                if (Object.keys(colWidths).length > 0) {
+                    $wire.colWidths = colWidths;
+                    $wire.storeColWidths(colWidths);
+                }
+            };
+
+            document.body.style.cursor = 'col-resize';
+            document.body.style.userSelect = 'none';
+            document.addEventListener('mousemove', onMouseMove);
+            document.addEventListener('mouseup', onMouseUp);
+        },
         init() {
             this.$watch(() => JSON.stringify($wire.textFilters), () => {
                 const tf = $wire.textFilters || {};

--- a/resources/views/components/layouts/table.blade.php
+++ b/resources/views/components/layouts/table.blade.php
@@ -17,13 +17,16 @@
     'allowSoftDeletes' => false,
     'showRestoreButton' => false,
     'isSortable' => false,
+    'isResizable' => false,
 ])
 <div
     class="mt-3 flex flex-col"
     x-data="{ showSelectedActions: false }"
 >
     <div class="relative overflow-x-auto shadow-sm sm:rounded-lg">
-        <table class="dark:bg-secondary-800 min-w-full table-auto border-collapse bg-white text-sm text-gray-500 dark:text-gray-50">
+        <table class="dark:bg-secondary-800 min-w-full border-collapse bg-white text-sm text-gray-500 dark:text-gray-50"
+            x-bind:class="Object.keys($wire.colWidths || {}).length > 0 ? 'table-fixed' : 'table-auto'"
+        >
             <thead style="z-index: 9">
                 @if ($hasHead)
                     <tr>
@@ -52,7 +55,7 @@
                         <template x-for="col in $wire.enabledCols" x-bind:key="col">
                             <x-tall-datatables::table.head-cell
                                 x-bind:class="($wire.stickyCols || []).includes(col) ? 'left-0 z-10 border-r' : ''"
-                                x-bind:style="($wire.stickyCols || []).includes(col) ? 'z-index: 2' : 'z-index: 1'"
+                                x-bind:style="[($wire.stickyCols || []).includes(col) ? 'z-index: 2' : 'z-index: 1', ($wire.colWidths || {})[col] ? 'width: ' + ($wire.colWidths || {})[col] + 'px' : ''].filter(Boolean).join('; ')"
                                 :attributes="$tableHeadColAttributes"
                             >
                                 <div class="group flex items-center gap-1">
@@ -123,6 +126,12 @@
                                         />
                                     @endif
                                 </div>
+                                @if ($isResizable)
+                                    <div
+                                        class="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary-400 transition-colors"
+                                        x-on:mousedown="startResize($event, col)"
+                                    ></div>
+                                @endif
                             </x-tall-datatables::table.head-cell>
                         </template>
                         @if ($rowActions)

--- a/resources/views/components/table/head-cell.blade.php
+++ b/resources/views/components/table/head-cell.blade.php
@@ -1,5 +1,5 @@
 <th
-    {{ $attributes->merge(['style' => 'z-index: 1', 'class' => 'table-cell whitespace-nowrap px-3 py-2.5 text-sm font-medium text-gray-500 dark:text-gray-400 bg-white dark:bg-secondary-800 sticky top-0 border-b border-gray-200 dark:border-secondary-700/50']) }}
+    {{ $attributes->merge(['style' => 'z-index: 1', 'class' => 'relative table-cell whitespace-nowrap px-3 py-2.5 text-sm font-medium text-gray-500 dark:text-gray-400 bg-white dark:bg-secondary-800 sticky top-0 border-b border-gray-200 dark:border-secondary-700/50']) }}
 >
     {{ $slot ?? '' }}
 </th>

--- a/resources/views/livewire/data-table.blade.php
+++ b/resources/views/livewire/data-table.blade.php
@@ -55,6 +55,7 @@
         :allow-soft-deletes="$allowSoftDeletes"
         :show-restore-button="$showRestoreButton"
         :is-sortable="$isSortable"
+        :is-resizable="$isResizable"
     />
     @includeWhen($includeAfter, $includeAfter)
 </x-tall-datatables::data-table-wrapper>

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -48,6 +48,8 @@ class DataTable extends Component
 
     public array $columnLabels = [];
 
+    public array $colWidths = [];
+
     public array $data = [];
 
     public array $enabledCols = [];
@@ -58,8 +60,6 @@ class DataTable extends Component
     public array $filterValueLists = [];
 
     public array $formatters = [];
-
-    public array $colWidths = [];
 
     #[Locked]
     public bool $hasHead = true;
@@ -849,6 +849,13 @@ class DataTable extends Component
         $this->loadData();
     }
 
+    #[Renderless]
+    public function storeColWidths(array $colWidths): void
+    {
+        $this->colWidths = $colWidths;
+        $this->cacheState();
+    }
+
     public function updatedSearch(): void
     {
         $this->startSearch();
@@ -1131,6 +1138,11 @@ class DataTable extends Component
         return $this->cachedViewData;
     }
 
+    protected function isResizable(): bool
+    {
+        return config('tall-datatables.resizable_columns', false);
+    }
+
     protected function kanbanCardView(): ?string
     {
         return null;
@@ -1172,18 +1184,6 @@ class DataTable extends Component
         }
 
         return $resolved;
-    }
-
-    protected function isResizable(): bool
-    {
-        return config('tall-datatables.resizable_columns', false);
-    }
-
-    #[Renderless]
-    public function storeColWidths(array $colWidths): void
-    {
-        $this->colWidths = $colWidths;
-        $this->cacheState();
     }
 
     protected function setData(array $data): void

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -1140,7 +1140,7 @@ class DataTable extends Component
 
     protected function isResizable(): bool
     {
-        return config('tall-datatables.resizable_columns', false);
+        return true;
     }
 
     protected function kanbanCardView(): ?string

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -59,6 +59,8 @@ class DataTable extends Component
 
     public array $formatters = [];
 
+    public array $colWidths = [];
+
     #[Locked]
     public bool $hasHead = true;
 
@@ -1118,6 +1120,7 @@ class DataTable extends Component
             'canSaveDefaultColumns' => $this->canSaveDefaultColumns(),
             'canShareFilters' => $this->canShareFilters(),
             'isSortable' => $this->isSortable(),
+            'isResizable' => $this->isResizable(),
             'availableLayouts' => $this->availableLayouts(),
             'activeLayout' => $this->activeLayout,
             'kanbanColumn' => in_array('kanban', $this->availableLayouts()) ? $this->kanbanColumn() : null,
@@ -1169,6 +1172,18 @@ class DataTable extends Component
         }
 
         return $resolved;
+    }
+
+    protected function isResizable(): bool
+    {
+        return config('tall-datatables.resizable_columns', false);
+    }
+
+    #[Renderless]
+    public function storeColWidths(array $colWidths): void
+    {
+        $this->colWidths = $colWidths;
+        $this->cacheState();
     }
 
     protected function setData(array $data): void

--- a/src/Traits/DataTables/StoresSettings.php
+++ b/src/Traits/DataTables/StoresSettings.php
@@ -329,6 +329,7 @@ trait StoresSettings
             'search' => $this->search,
             'selected' => $this->selected,
             'groupBy' => $this->groupBy,
+            'colWidths' => $this->colWidths,
         ];
 
         if (config('tall-datatables.should_cache')) {
@@ -374,6 +375,7 @@ trait StoresSettings
                 'aggregatableCols' => $this->aggregatableCols,
                 'perPage' => $this->perPage,
                 'activeLayout' => $this->activeLayout,
+                'colWidths' => $this->colWidths,
             ],
             'is_layout' => true,
         ];

--- a/tests/Browser/ResizableColumnsBrowserTest.php
+++ b/tests/Browser/ResizableColumnsBrowserTest.php
@@ -7,7 +7,6 @@
  * Requires: pestphp/pest-plugin-browser, built assets (npm run build).
  */
 
-use Tests\Fixtures\Livewire\PostDataTable;
 use Tests\Fixtures\Livewire\ResizablePostDataTable;
 
 beforeEach(function (): void {
@@ -28,25 +27,7 @@ beforeEach(function (): void {
     }
 });
 
-describe('Resizable columns - disabled', function (): void {
-    it('does not render resize handles when isResizable is false', function (): void {
-        config()->set('tall-datatables.resizable_columns', false);
-
-        $page = visitLivewire(PostDataTable::class);
-
-        $page->wait(2);
-
-        $result = $page->script('() => {
-            return document.querySelectorAll(".cursor-col-resize").length;
-        }');
-
-        $count = is_array($result) && isset($result[0]) ? $result[0] : $result;
-
-        expect($count)->toBe(0);
-    });
-});
-
-describe('Resizable columns - enabled', function (): void {
+describe('Resizable columns', function (): void {
     it('renders resize handles on column headers', function (): void {
         $page = visitLivewire(ResizablePostDataTable::class);
 

--- a/tests/Browser/ResizableColumnsBrowserTest.php
+++ b/tests/Browser/ResizableColumnsBrowserTest.php
@@ -1,0 +1,258 @@
+<?php
+
+/**
+ * Browser Tests for Resizable Columns
+ *
+ * Tests the column resize interaction in a real browser via Playwright.
+ * Requires: pestphp/pest-plugin-browser, built assets (npm run build).
+ */
+
+use Tests\Fixtures\Livewire\PostDataTable;
+use Tests\Fixtures\Livewire\ResizablePostDataTable;
+
+beforeEach(function (): void {
+    $manifestPath = dirname(__DIR__, 2) . '/dist/build/manifest.json';
+    if (! file_exists($manifestPath)) {
+        $this->markTestSkipped('Browser tests require built assets. Run: npm run build');
+    }
+
+    $this->user = createTestUser(['name' => 'Test User', 'email' => 'resize@example.com']);
+
+    for ($i = 1; $i <= 5; $i++) {
+        createTestPost([
+            'user_id' => $this->user->getKey(),
+            'title' => "Post Title {$i}",
+            'content' => "Content {$i}",
+            'is_published' => true,
+        ]);
+    }
+});
+
+describe('Resizable columns - disabled', function (): void {
+    it('does not render resize handles when isResizable is false', function (): void {
+        config()->set('tall-datatables.resizable_columns', false);
+
+        $page = visitLivewire(PostDataTable::class);
+
+        $page->wait(2);
+
+        $result = $page->script('() => {
+            return document.querySelectorAll(".cursor-col-resize").length;
+        }');
+
+        $count = is_array($result) && isset($result[0]) ? $result[0] : $result;
+
+        expect($count)->toBe(0);
+    });
+});
+
+describe('Resizable columns - enabled', function (): void {
+    it('renders resize handles on column headers', function (): void {
+        $page = visitLivewire(ResizablePostDataTable::class);
+
+        $page->wait(2);
+
+        $result = $page->script('() => {
+            return document.querySelectorAll(".cursor-col-resize").length;
+        }');
+
+        $count = is_array($result) && isset($result[0]) ? $result[0] : $result;
+
+        expect($count)->toBeGreaterThan(0);
+    });
+
+    it('starts with table-auto class', function (): void {
+        $page = visitLivewire(ResizablePostDataTable::class);
+
+        $page->wait(2);
+
+        $result = $page->script('() => {
+            const table = document.querySelector("table");
+            return table?.classList.contains("table-auto");
+        }');
+
+        $hasClass = is_array($result) && isset($result[0]) ? $result[0] : $result;
+
+        expect($hasClass)->toBeTrue();
+    });
+
+    it('switches to table-fixed and sets width on drag', function (): void {
+        $page = visitLivewire(ResizablePostDataTable::class);
+
+        $page->wait(2);
+
+        // Simulate a column resize drag on the first resizable column
+        $result = $page->script('() => {
+            return new Promise((resolve) => {
+                const handle = document.querySelector(".cursor-col-resize");
+                if (!handle) return resolve({ error: "no handle found" });
+
+                const th = handle.closest("th");
+                const table = th.closest("table");
+                const startWidth = th.offsetWidth;
+                const rect = handle.getBoundingClientRect();
+
+                // Simulate mousedown
+                handle.dispatchEvent(new MouseEvent("mousedown", {
+                    clientX: rect.left,
+                    clientY: rect.top + rect.height / 2,
+                    bubbles: true,
+                }));
+
+                // Simulate mousemove (drag 100px right)
+                document.dispatchEvent(new MouseEvent("mousemove", {
+                    clientX: rect.left + 100,
+                    clientY: rect.top + rect.height / 2,
+                    bubbles: true,
+                }));
+
+                // Simulate mouseup
+                document.dispatchEvent(new MouseEvent("mouseup", {
+                    clientX: rect.left + 100,
+                    clientY: rect.top + rect.height / 2,
+                    bubbles: true,
+                }));
+
+                // Wait for Livewire to process
+                setTimeout(() => {
+                    resolve({
+                        isTableFixed: table.classList.contains("table-fixed"),
+                        hasWidth: !!th.style.width,
+                        newWidth: parseInt(th.style.width, 10) || 0,
+                        startWidth: startWidth,
+                    });
+                }, 500);
+            });
+        }');
+
+        $data = is_array($result) && isset($result[0]) ? $result[0] : $result;
+
+        expect($data['isTableFixed'])->toBeTrue();
+        expect($data['hasWidth'])->toBeTrue();
+        expect($data['newWidth'])->toBeGreaterThan(0);
+    });
+
+    it('enforces minimum column width of 50px', function (): void {
+        $page = visitLivewire(ResizablePostDataTable::class);
+
+        $page->wait(2);
+
+        $result = $page->script('() => {
+            return new Promise((resolve) => {
+                const handle = document.querySelector(".cursor-col-resize");
+                if (!handle) return resolve({ error: "no handle found" });
+
+                const th = handle.closest("th");
+                const rect = handle.getBoundingClientRect();
+
+                // Simulate mousedown
+                handle.dispatchEvent(new MouseEvent("mousedown", {
+                    clientX: rect.left,
+                    clientY: rect.top + rect.height / 2,
+                    bubbles: true,
+                }));
+
+                // Drag far left to shrink below minimum
+                document.dispatchEvent(new MouseEvent("mousemove", {
+                    clientX: rect.left - 1000,
+                    clientY: rect.top + rect.height / 2,
+                    bubbles: true,
+                }));
+
+                document.dispatchEvent(new MouseEvent("mouseup", {
+                    clientX: rect.left - 1000,
+                    bubbles: true,
+                }));
+
+                setTimeout(() => {
+                    resolve({
+                        width: parseInt(th.style.width, 10) || 0,
+                    });
+                }, 200);
+            });
+        }');
+
+        $data = is_array($result) && isset($result[0]) ? $result[0] : $result;
+
+        expect($data['width'])->toBeGreaterThanOrEqual(50);
+    });
+
+    it('persists column widths to Livewire after resize', function (): void {
+        $page = visitLivewire(ResizablePostDataTable::class);
+
+        $page->wait(2);
+
+        // Perform resize and check Livewire state
+        $result = $page->script('() => {
+            return new Promise((resolve) => {
+                const handle = document.querySelector(".cursor-col-resize");
+                if (!handle) return resolve({ error: "no handle found" });
+
+                const th = handle.closest("th");
+                const rect = handle.getBoundingClientRect();
+
+                handle.dispatchEvent(new MouseEvent("mousedown", {
+                    clientX: rect.left,
+                    clientY: rect.top + rect.height / 2,
+                    bubbles: true,
+                }));
+
+                document.dispatchEvent(new MouseEvent("mousemove", {
+                    clientX: rect.left + 50,
+                    clientY: rect.top + rect.height / 2,
+                    bubbles: true,
+                }));
+
+                document.dispatchEvent(new MouseEvent("mouseup", {
+                    clientX: rect.left + 50,
+                    bubbles: true,
+                }));
+
+                // Wait for Livewire to sync
+                setTimeout(() => {
+                    const comp = document.querySelector("[wire\\\\:id]");
+                    const wireId = comp?.getAttribute("wire:id");
+                    const colWidths = window.Livewire?.find(wireId)?.get("colWidths") || {};
+                    resolve({
+                        hasWidths: Object.keys(colWidths).length > 0,
+                        colWidths: colWidths,
+                    });
+                }, 2000);
+            });
+        }');
+
+        $data = is_array($result) && isset($result[0]) ? $result[0] : $result;
+
+        expect($data['hasWidths'])->toBeTrue();
+    });
+
+    it('has no JavaScript errors during resize', function (): void {
+        $page = visitLivewire(ResizablePostDataTable::class);
+
+        $page->wait(2);
+
+        // Perform a resize
+        $page->script('() => {
+            return new Promise((resolve) => {
+                const handle = document.querySelector(".cursor-col-resize");
+                if (!handle) return resolve();
+
+                const rect = handle.getBoundingClientRect();
+
+                handle.dispatchEvent(new MouseEvent("mousedown", {
+                    clientX: rect.left, clientY: rect.top, bubbles: true,
+                }));
+                document.dispatchEvent(new MouseEvent("mousemove", {
+                    clientX: rect.left + 50, clientY: rect.top, bubbles: true,
+                }));
+                document.dispatchEvent(new MouseEvent("mouseup", {
+                    clientX: rect.left + 50, bubbles: true,
+                }));
+
+                setTimeout(resolve, 500);
+            });
+        }');
+
+        $page->assertNoJavascriptErrors();
+    });
+});

--- a/tests/Feature/ResizableColumnsTest.php
+++ b/tests/Feature/ResizableColumnsTest.php
@@ -9,18 +9,7 @@ beforeEach(function (): void {
 });
 
 describe('Resizable columns', function (): void {
-    test('isResizable defaults to config value', function (): void {
-        config()->set('tall-datatables.resizable_columns', false);
-
-        $component = Livewire::test(PostDataTable::class);
-        $viewData = $component->instance()->getIslandData();
-
-        expect($viewData['isResizable'])->toBeFalse();
-    });
-
-    test('isResizable returns true when config enabled', function (): void {
-        config()->set('tall-datatables.resizable_columns', true);
-
+    test('isResizable is always true', function (): void {
         $component = Livewire::test(PostDataTable::class);
         $viewData = $component->instance()->getIslandData();
 

--- a/tests/Feature/ResizableColumnsTest.php
+++ b/tests/Feature/ResizableColumnsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Livewire\Livewire;
+use Tests\Fixtures\Livewire\PostDataTable;
+
+beforeEach(function (): void {
+    $this->user = createTestUser();
+    $this->actingAs($this->user);
+});
+
+describe('Resizable columns', function (): void {
+    test('isResizable defaults to config value', function (): void {
+        config()->set('tall-datatables.resizable_columns', false);
+
+        $component = Livewire::test(PostDataTable::class);
+        $viewData = $component->instance()->getIslandData();
+
+        expect($viewData['isResizable'])->toBeFalse();
+    });
+
+    test('isResizable returns true when config enabled', function (): void {
+        config()->set('tall-datatables.resizable_columns', true);
+
+        $component = Livewire::test(PostDataTable::class);
+        $viewData = $component->instance()->getIslandData();
+
+        expect($viewData['isResizable'])->toBeTrue();
+    });
+
+    test('colWidths defaults to empty array', function (): void {
+        $component = Livewire::test(PostDataTable::class);
+
+        expect($component->get('colWidths'))->toBe([]);
+    });
+
+    test('storeColWidths persists column widths', function (): void {
+        $widths = ['title' => 200, 'content' => 300];
+
+        $component = Livewire::test(PostDataTable::class)
+            ->call('storeColWidths', $widths);
+
+        expect($component->get('colWidths'))->toBe($widths);
+    });
+
+    test('resetLayout clears colWidths', function (): void {
+        $component = Livewire::test(PostDataTable::class)
+            ->call('storeColWidths', ['title' => 200])
+            ->call('resetLayout');
+
+        expect($component->get('colWidths'))->toBe([]);
+    });
+});

--- a/tests/Feature/StoresSettingsTest.php
+++ b/tests/Feature/StoresSettingsTest.php
@@ -919,6 +919,7 @@ describe('cacheState (via SupportsCache)', function (): void {
             'search',
             'selected',
             'groupBy',
+            'colWidths',
         ]);
     });
 

--- a/tests/Fixtures/Livewire/ResizablePostDataTable.php
+++ b/tests/Fixtures/Livewire/ResizablePostDataTable.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Fixtures\Livewire;
+
+use Livewire\Attributes\Layout;
+use TeamNiftyGmbH\DataTable\DataTable;
+use Tests\Fixtures\Models\Post;
+
+#[Layout('components.layouts.app')]
+class ResizablePostDataTable extends DataTable
+{
+    public array $enabledCols = [
+        'title',
+        'content',
+        'price',
+        'is_published',
+        'created_at',
+    ];
+
+    public bool $isSelectable = true;
+
+    protected string $model = Post::class;
+
+    protected function isResizable(): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `resizable_columns` config option (default: false, env: `TALL_DATATABLES_RESIZABLE_COLUMNS`)
- `isResizable()` method on DataTable, overridable per component
- Drag resize handles on column headers, switches table to `table-fixed`
- Column widths persist per user via existing layout settings system
- Layout reset clears custom widths back to auto-sizing
- 5 feature tests + 7 browser tests (Playwright)