### PR TITLE
Strip HTML tags in StringFormatter

### DIFF
--- a/src/Formatters/StringFormatter.php
+++ b/src/Formatters/StringFormatter.php
@@ -12,6 +12,6 @@ class StringFormatter implements Formatter
             return '';
         }
 
-        return e((string) $value);
+        return e(strip_tags((string) $value));
     }
 }

--- a/tests/Unit/Formatters/StringFormatterTest.php
+++ b/tests/Unit/Formatters/StringFormatterTest.php
@@ -27,11 +27,18 @@ describe('StringFormatter', function (): void {
         expect($formatter->format(3.14))->toBe('3.14');
     });
 
-    it('escapes HTML entities', function (): void {
+    it('strips HTML tags and escapes remaining content', function (): void {
         $formatter = new StringFormatter();
 
         expect($formatter->format('<script>alert("xss")</script>'))
-            ->toBe('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;');
+            ->toBe('alert(&quot;xss&quot;)');
+    });
+
+    it('strips rich text HTML to plain text', function (): void {
+        $formatter = new StringFormatter();
+
+        expect($formatter->format('<p>Hello <b>World</b></p>'))
+            ->toBe('Hello World');
     });
 
     it('escapes ampersands', function (): void {

--- a/tests/Unit/Support/RowTransformerTest.php
+++ b/tests/Unit/Support/RowTransformerTest.php
@@ -160,7 +160,7 @@ describe('RowTransformer::transform', function (): void {
         expect($row)->toHaveKey('post.user.name');
     });
 
-    it('omits display key when formatter escapes same as e(raw)', function (): void {
+    it('wraps HTML string with stripped display value', function (): void {
         $registry = new FormatterRegistry();
         $transformer = new RowTransformer($registry);
 
@@ -168,9 +168,10 @@ describe('RowTransformer::transform', function (): void {
 
         $row = $transformer->transform($post, ['title']);
 
-        // StringFormatter calls e() which matches e(rawString), so display is omitted
-        expect($row['title'])->not->toHaveKey('display');
-        expect($row['title']['raw'])->toBe('<b>Bold</b>');
+        // StringFormatter strips tags and escapes, producing a different display value
+        expect($row['title'])->toHaveKeys(['raw', 'display'])
+            ->and($row['title']['raw'])->toBe('<b>Bold</b>')
+            ->and($row['title']['display'])->toBe('Bold');
     });
 
     it('uses correct base column for dot-notation casts resolution', function (): void {


### PR DESCRIPTION
## Summary
- `StringFormatter` now uses `strip_tags()` before `e()` so HTML content in string columns is displayed as clean plain text instead of escaped HTML entities
- Values like `<p>Hello <b>World</b></p>` render as "Hello World" instead of `&lt;p&gt;Hello &lt;b&gt;World&lt;/b&gt;&lt;/p&gt;`