### PR TITLE
Add test artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .idea
 .phpunit.result.cache
+.phpunit.cache
+build
 composer.lock
 package-lock.json
 coverage


### PR DESCRIPTION
## Summary
- Add `.phpunit.cache/` and `build/` to `.gitignore` to prevent generated test artifacts from being tracked