### PR TITLE
Restore left/right/top/bottom append rendering in table rows

### DIFF
--- a/resources/views/components/layouts/partials/table-row.blade.php
+++ b/resources/views/components/layouts/partials/table-row.blade.php
@@ -12,6 +12,10 @@
     'showRestoreButton' => false,
     'hasSidebar' => true,
     'isSortable' => false,
+    'leftAppend' => [],
+    'rightAppend' => [],
+    'topAppend' => [],
+    'bottomAppend' => [],
 ])
 @php
     $modelKeyName = $this->modelKeyName;
@@ -51,12 +55,26 @@
             :style="in_array($col, $this->stickyCols) ? 'z-index: 2' : ''"
             :href="(($allowSoftDeletes && ($record['deleted_at'] ?? null)) ? null : ($record['href'] ?? null))"
         >
-            @if (is_array($record[$col] ?? null) && isset($record[$col]['display']))
-                {!! $record[$col]['display'] !!}
-            @elseif (is_array($record[$col] ?? null) && isset($record[$col]['raw']))
-                {{ $record[$col]['raw'] }}
-            @else
-                {{ $record[$col] ?? '' }}
+            @if (isset($topAppend[$col]) && is_string($record[$topAppend[$col]] ?? null))
+                <div>{!! $record[$topAppend[$col]] !!}</div>
+            @endif
+            <div class="flex items-center">
+                @if (isset($leftAppend[$col]) && is_string($record[$leftAppend[$col]] ?? null))
+                    {!! $record[$leftAppend[$col]] !!}
+                @endif
+                @if (is_array($record[$col] ?? null) && isset($record[$col]['display']))
+                    {!! $record[$col]['display'] !!}
+                @elseif (is_array($record[$col] ?? null) && isset($record[$col]['raw']))
+                    {{ $record[$col]['raw'] }}
+                @else
+                    {{ $record[$col] ?? '' }}
+                @endif
+                @if (isset($rightAppend[$col]) && is_string($record[$rightAppend[$col]] ?? null))
+                    {!! $record[$rightAppend[$col]] !!}
+                @endif
+            </div>
+            @if (isset($bottomAppend[$col]) && is_string($record[$bottomAppend[$col]] ?? null))
+                <div>{!! $record[$bottomAppend[$col]] !!}</div>
             @endif
         </x-tall-datatables::table.cell>
     @endforeach

--- a/resources/views/components/layouts/table.blade.php
+++ b/resources/views/components/layouts/table.blade.php
@@ -380,6 +380,10 @@
                             :show-restore-button="$showRestoreButton"
                             :has-sidebar="$hasSidebar"
                             :is-sortable="$isSortable"
+                            :left-append="$leftAppend ?? []"
+                            :right-append="$rightAppend ?? []"
+                            :top-append="$topAppend ?? []"
+                            :bottom-append="$bottomAppend ?? []"
                         />
                     @endforeach
                 @endif

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -1123,6 +1123,10 @@ class DataTable extends Component
             'kanbanColumn' => in_array('kanban', $this->availableLayouts()) ? $this->kanbanColumn() : null,
             'kanbanLanes' => in_array('kanban', $this->availableLayouts()) ? $this->resolveKanbanLanes() : null,
             'kanbanCardView' => in_array('kanban', $this->availableLayouts()) ? $this->kanbanCardView() : null,
+            'leftAppend' => $this->getLeftAppends(),
+            'rightAppend' => $this->getRightAppends(),
+            'topAppend' => $this->getTopAppends(),
+            'bottomAppend' => $this->getBottomAppends(),
         ];
 
         return $this->cachedViewData;


### PR DESCRIPTION
## Summary
- The append rendering was removed during the JS-to-Blade migration (80ac842)
- Data was still passed via `getConfig()` but never used in the server-rendered table-row template
- This broke indentation in CategoryList and other DataTables using `getLeftAppends()` / `getRightAppends()`

Fix: add all append arrays to `getViewData()`, pass them as props to `table-row` component, render them around cell content in the Blade template