### PR TITLE
Fix append rendering for array keys and formatted values

### DIFF
--- a/resources/views/components/layouts/partials/table-row.blade.php
+++ b/resources/views/components/layouts/partials/table-row.blade.php
@@ -55,26 +55,56 @@
             :style="in_array($col, $this->stickyCols) ? 'z-index: 2' : ''"
             :href="(($allowSoftDeletes && ($record['deleted_at'] ?? null)) ? null : ($record['href'] ?? null))"
         >
-            @if (isset($topAppend[$col]) && is_string($record[$topAppend[$col]] ?? null))
-                <div>{!! $record[$topAppend[$col]] !!}</div>
+            @php
+                $hasLeftAppend = isset($leftAppend[$col]);
+                $hasRightAppend = isset($rightAppend[$col]);
+                $hasTopAppend = isset($topAppend[$col]);
+                $hasBottomAppend = isset($bottomAppend[$col]);
+            @endphp
+            @if ($hasTopAppend)
+                @foreach (\Illuminate\Support\Arr::wrap($topAppend[$col]) as $appendKey)
+                    @if (is_array($record[$appendKey] ?? null) && isset($record[$appendKey]['display']))
+                        <div>{!! $record[$appendKey]['display'] !!}</div>
+                    @elseif (is_string($record[$appendKey] ?? null))
+                        <div>{!! $record[$appendKey] !!}</div>
+                    @endif
+                @endforeach
             @endif
-            <div class="flex items-center">
-                @if (isset($leftAppend[$col]) && is_string($record[$leftAppend[$col]] ?? null))
-                    {!! $record[$leftAppend[$col]] !!}
-                @endif
-                @if (is_array($record[$col] ?? null) && isset($record[$col]['display']))
-                    {!! $record[$col]['display'] !!}
-                @elseif (is_array($record[$col] ?? null) && isset($record[$col]['raw']))
-                    {{ $record[$col]['raw'] }}
-                @else
-                    {{ $record[$col] ?? '' }}
-                @endif
-                @if (isset($rightAppend[$col]) && is_string($record[$rightAppend[$col]] ?? null))
-                    {!! $record[$rightAppend[$col]] !!}
-                @endif
-            </div>
-            @if (isset($bottomAppend[$col]) && is_string($record[$bottomAppend[$col]] ?? null))
-                <div>{!! $record[$bottomAppend[$col]] !!}</div>
+            @if ($hasLeftAppend || $hasRightAppend)
+                <div class="flex items-center gap-2">
+                    @foreach (\Illuminate\Support\Arr::wrap($leftAppend[$col] ?? []) as $appendKey)
+                        @if (is_array($record[$appendKey] ?? null) && isset($record[$appendKey]['display']))
+                            {!! $record[$appendKey]['display'] !!}
+                        @elseif (is_string($record[$appendKey] ?? null))
+                            {!! $record[$appendKey] !!}
+                        @endif
+                    @endforeach
+            @endif
+            @if (is_array($record[$col] ?? null) && isset($record[$col]['display']))
+                {!! $record[$col]['display'] !!}
+            @elseif (is_array($record[$col] ?? null) && isset($record[$col]['raw']))
+                {{ $record[$col]['raw'] }}
+            @else
+                {{ $record[$col] ?? '' }}
+            @endif
+            @if ($hasLeftAppend || $hasRightAppend)
+                    @foreach (\Illuminate\Support\Arr::wrap($rightAppend[$col] ?? []) as $appendKey)
+                        @if (is_array($record[$appendKey] ?? null) && isset($record[$appendKey]['display']))
+                            {!! $record[$appendKey]['display'] !!}
+                        @elseif (is_string($record[$appendKey] ?? null))
+                            {!! $record[$appendKey] !!}
+                        @endif
+                    @endforeach
+                </div>
+            @endif
+            @if ($hasBottomAppend)
+                @foreach (\Illuminate\Support\Arr::wrap($bottomAppend[$col]) as $appendKey)
+                    @if (is_array($record[$appendKey] ?? null) && isset($record[$appendKey]['display']))
+                        <div>{!! $record[$appendKey]['display'] !!}</div>
+                    @elseif (is_string($record[$appendKey] ?? null))
+                        <div>{!! $record[$appendKey] !!}</div>
+                    @endif
+                @endforeach
             @endif
         </x-tall-datatables::table.cell>
     @endforeach

--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -168,7 +168,21 @@ trait BuildsQueries
         $context['_dbTimezone'] = $this->getDatabaseTimezone();
         $context['_displayTimezone'] = $this->getDisplayTimezone();
 
-        foreach ($this->enabledCols as $col) {
+        $appendKeys = collect([
+            $this->getLeftAppends(),
+            $this->getRightAppends(),
+            $this->getTopAppends(),
+            $this->getBottomAppends(),
+        ])
+            ->flatMap(fn (array $appends) => collect($appends)->flatMap(
+                fn ($keys) => \Illuminate\Support\Arr::wrap($keys)
+            ))
+            ->unique()
+            ->all();
+
+        $colsToFormat = array_unique(array_merge($this->enabledCols, $appendKeys));
+
+        foreach ($colsToFormat as $col) {
             if (! array_key_exists($col, $itemArray)) {
                 continue;
             }
@@ -292,7 +306,21 @@ trait BuildsQueries
         $modelCasts = $item->getCasts();
         $this->resolvedFormatters = [];
 
-        foreach ($this->enabledCols as $col) {
+        $appendKeys = collect([
+            $this->getLeftAppends(),
+            $this->getRightAppends(),
+            $this->getTopAppends(),
+            $this->getBottomAppends(),
+        ])
+            ->flatMap(fn (array $appends) => collect($appends)->flatMap(
+                fn ($keys) => \Illuminate\Support\Arr::wrap($keys)
+            ))
+            ->unique()
+            ->all();
+
+        $colsToResolve = array_unique(array_merge($this->enabledCols, $appendKeys));
+
+        foreach ($colsToResolve as $col) {
             $baseCol = str_contains($col, '.') ? last(explode('.', $col)) : $col;
 
             if (isset($customFormatters[$col]) && is_string($customFormatters[$col])) {

--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -175,7 +175,7 @@ trait BuildsQueries
             $this->getBottomAppends(),
         ])
             ->flatMap(fn (array $appends) => collect($appends)->flatMap(
-                fn ($keys) => \Illuminate\Support\Arr::wrap($keys)
+                fn ($keys) => Arr::wrap($keys)
             ))
             ->unique()
             ->all();
@@ -313,7 +313,7 @@ trait BuildsQueries
             $this->getBottomAppends(),
         ])
             ->flatMap(fn (array $appends) => collect($appends)->flatMap(
-                fn ($keys) => \Illuminate\Support\Arr::wrap($keys)
+                fn ($keys) => Arr::wrap($keys)
             ))
             ->unique()
             ->all();


### PR DESCRIPTION
## Summary
Fixes the `Cannot access offset of type array on array` error when append values use array keys (e.g. `'name' => ['product_image']` in ProductList).

- Use `Arr::wrap()` to handle both string and array append keys
- Support formatted values (`['display' => ...]`) in append rendering (e.g. image formatter)
- Include append keys in `getResolvedFormatters()` and `applyFormatters()` so formatters like `image` are applied
- Only wrap cells in flex container when left/right appends actually exist
- Add `gap-2` spacing between append content and cell value