### PR TITLE
Allow sortTable('') to clear sorting

### DIFF
--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -803,6 +803,16 @@ class DataTable extends Component
     #[Renderless]
     public function sortTable(string $col, bool $append = false): void
     {
+        if ($col === '') {
+            $this->userOrderBy = '';
+            $this->userOrderAsc = true;
+            $this->userMultiSort = [];
+            $this->cacheState();
+            $this->loadData();
+
+            return;
+        }
+
         if (! $this->isValidSortColumn($col)) {
             return;
         }

--- a/tests/Browser/DataTableBrowserTest.php
+++ b/tests/Browser/DataTableBrowserTest.php
@@ -470,11 +470,11 @@ describe('DataTable Browser Sorting', function (): void {
             });
         }');
 
-        // Clear sort via clearFiltersAndSort (sortTable("") is rejected by validation)
+        // Clear sort via sortTable("") — now accepted as "clear sort"
         $page->script('() => {
             const comp = document.querySelector("[wire\\\\:id]");
             const wireId = comp?.getAttribute("wire:id");
-            window.Livewire?.find(wireId)?.call("clearFiltersAndSort");
+            window.Livewire?.find(wireId)?.call("sortTable", "");
         }');
 
         // Wait for sort to be cleared

--- a/tests/Feature/MultiSortTest.php
+++ b/tests/Feature/MultiSortTest.php
@@ -16,6 +16,20 @@ beforeEach(function (): void {
 });
 
 describe('Multi-Sort', function (): void {
+    describe('sortTable with empty string', function (): void {
+        it('clears sort when called with empty string', function (): void {
+            $component = Livewire::test(PostDataTable::class)
+                ->call('sortTable', 'title', false);
+
+            expect($component->get('userOrderBy'))->toBe('title');
+
+            $component->call('sortTable', '', false);
+
+            expect($component->get('userOrderBy'))->toBe('')
+                ->and($component->get('userMultiSort'))->toBe([]);
+        });
+    });
+
     describe('sortTable with append', function (): void {
         it('sets primary sort when append is false', function (): void {
             $component = Livewire::test(PostDataTable::class)


### PR DESCRIPTION
## Summary
- `sortTable('')` was rejected by `isValidSortColumn`, so the sort badge X button did nothing
- This caused a JS error (`Cannot read properties of undefined (reading 'querySelectorAll')`) because Livewire expected the badge to disappear but it stayed in the DOM
- Empty string is now treated as "clear all sorting" before validation runs
- Updated browser test that previously used `clearFiltersAndSort` as a workaround