### PR TITLE
Fix percentage formatter default multiplier

### DIFF
--- a/src/Formatters/FormatterRegistry.php
+++ b/src/Formatters/FormatterRegistry.php
@@ -114,7 +114,7 @@ class FormatterRegistry
             'money' => new MoneyFormatter(),
             'coloredmoney' => new MoneyFormatter(colored: true),
             'percentage' => new PercentageFormatter(),
-            'progresspercentage' => new PercentageFormatter(progressBar: true, multiplier: 100),
+            'progresspercentage' => new PercentageFormatter(progressBar: true),
             'coloredfloat' => new FloatFormatter(colored: true),
             'state', 'badge' => new BadgeFormatter(),
             'email' => new LinkFormatter(type: 'email'),

--- a/src/Formatters/PercentageFormatter.php
+++ b/src/Formatters/PercentageFormatter.php
@@ -8,7 +8,7 @@ class PercentageFormatter implements Formatter
 {
     public function __construct(
         public readonly bool $progressBar = false,
-        public readonly float $multiplier = 1,
+        public readonly float $multiplier = 100,
     ) {}
 
     public function format(mixed $value, array $context = []): string

--- a/tests/Unit/Formatters/ArrayFormatterTest.php
+++ b/tests/Unit/Formatters/ArrayFormatterTest.php
@@ -124,7 +124,7 @@ describe('ArrayFormatter', function (): void {
         $percentageFormatter = new TeamNiftyGmbH\DataTable\Formatters\PercentageFormatter();
         $formatter = new ArrayFormatter(elementFormatter: $percentageFormatter);
 
-        $result = $formatter->format([42, 85]);
+        $result = $formatter->format([0.42, 0.85]);
 
         expect($result)
             ->toContain('rounded-full')
@@ -136,7 +136,7 @@ describe('ArrayFormatter', function (): void {
         $percentageFormatter = new TeamNiftyGmbH\DataTable\Formatters\PercentageFormatter();
         $formatter = new ArrayFormatter(elementFormatter: $percentageFormatter);
 
-        $result = $formatter->format([42, null, 85]);
+        $result = $formatter->format([0.42, null, 0.85]);
 
         expect($result)
             ->toContain('>42 %</span>')

--- a/tests/Unit/Formatters/PercentageFormatterTest.php
+++ b/tests/Unit/Formatters/PercentageFormatterTest.php
@@ -9,33 +9,33 @@ describe('PercentageFormatter', function (): void {
         expect($formatter->format(null))->toBe('');
     });
 
-    it('formats a plain percentage value', function (): void {
+    it('formats a decimal fraction as percentage', function (): void {
         $formatter = new PercentageFormatter();
 
-        expect($formatter->format(42))->toBe('42 %');
+        expect($formatter->format(0.42))->toBe('42 %');
     });
 
-    it('formats a decimal percentage', function (): void {
+    it('formats a decimal fraction with decimals', function (): void {
         $formatter = new PercentageFormatter();
 
-        expect($formatter->format(42.5))->toContain('%');
+        expect($formatter->format(0.195))->toBe('19,50 %');
     });
 
-    it('formats zero percent', function (): void {
+    it('formats zero', function (): void {
         $formatter = new PercentageFormatter();
 
         expect($formatter->format(0))->toBe('0 %');
     });
 
-    it('formats 100 percent', function (): void {
+    it('formats 1.0 as 100 percent', function (): void {
         $formatter = new PercentageFormatter();
 
-        expect($formatter->format(100))->toBe('100 %');
+        expect($formatter->format(1))->toBe('100 %');
     });
 
     it('renders progress bar with label and indigo color', function (): void {
         $formatter = new PercentageFormatter(progressBar: true);
-        $result = $formatter->format(50);
+        $result = $formatter->format(0.5);
 
         expect($result)
             ->toContain('<div')
@@ -46,14 +46,14 @@ describe('PercentageFormatter', function (): void {
 
     it('clamps progress bar to 0 for negative values', function (): void {
         $formatter = new PercentageFormatter(progressBar: true);
-        $result = $formatter->format(-10);
+        $result = $formatter->format(-0.1);
 
         expect($result)->toContain('width: 0.00%');
     });
 
     it('clamps progress bar to 100 for values over 100', function (): void {
         $formatter = new PercentageFormatter(progressBar: true);
-        $result = $formatter->format(150);
+        $result = $formatter->format(1.5);
 
         expect($result)->toContain('width: 100.00%');
     });
@@ -67,32 +67,14 @@ describe('PercentageFormatter', function (): void {
 
     it('renders progress bar for 100 percent', function (): void {
         $formatter = new PercentageFormatter(progressBar: true);
-        $result = $formatter->format(100);
+        $result = $formatter->format(1);
 
         expect($result)->toContain('width: 100.00%');
     });
 
-    it('renders progress bar with multiplier for decimal 1.0 as 100%', function (): void {
-        $formatter = new PercentageFormatter(progressBar: true, multiplier: 100);
+    it('renders text percentage with multiplier 1 for raw values', function (): void {
+        $formatter = new PercentageFormatter(multiplier: 1);
 
-        expect($formatter->format(1.0))->toContain('width: 100.00%');
-    });
-
-    it('renders progress bar with multiplier for decimal 0.5 as 50%', function (): void {
-        $formatter = new PercentageFormatter(progressBar: true, multiplier: 100);
-
-        expect($formatter->format(0.5))->toContain('width: 50.00%');
-    });
-
-    it('renders text percentage with multiplier for decimal 0.75', function (): void {
-        $formatter = new PercentageFormatter(multiplier: 100);
-
-        expect($formatter->format(0.75))->toBe('75 %');
-    });
-
-    it('renders progress bar with multiplier clamped to 100%', function (): void {
-        $formatter = new PercentageFormatter(progressBar: true, multiplier: 100);
-
-        expect($formatter->format(1.5))->toContain('width: 100.00%');
+        expect($formatter->format(75))->toBe('75 %');
     });
 });


### PR DESCRIPTION
## Summary
- Change `PercentageFormatter` default multiplier from `1` to `100`
- Percentage values stored as decimal fractions (0.19 for 19%) were displayed as "0,19 %" instead of "19 %"
- Remove now-redundant explicit `multiplier: 100` from `progresspercentage` in `FormatterRegistry`