### PR TITLE
Persist SessionFilter on DataTable instance for queued exports

### DIFF
--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -18,6 +18,7 @@ use Livewire\Component;
 use Livewire\Features\SupportIslands\Compiler\IslandCompiler;
 use TallStackUi\Traits\Interactions;
 use TeamNiftyGmbH\DataTable\Helpers\SchemaInfo;
+use TeamNiftyGmbH\DataTable\Helpers\SessionFilter;
 use TeamNiftyGmbH\DataTable\ModelInfo\Attribute;
 use TeamNiftyGmbH\DataTable\Traits\DataTables\BuildsQueries;
 use TeamNiftyGmbH\DataTable\Traits\DataTables\StoresSettings;
@@ -134,6 +135,8 @@ class DataTable extends Component
     protected $listeners = ['dataTableReload' => 'reloadData'];
 
     protected string $model;
+
+    protected ?SessionFilter $sessionFilterInstance = null;
 
     protected bool $useWireNavigate = true;
 
@@ -254,6 +257,7 @@ class DataTable extends Component
     {
         session()->forget($this->getCacheKey() . '_query');
         $this->sessionFilter = [];
+        $this->sessionFilterInstance = null;
 
         if ($loadData) {
             $this->loadData();

--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -805,22 +805,24 @@ trait BuildsQueries
      */
     private function applySessionFilter(Builder $query): void
     {
-        if (session()->has($this->getCacheKey() . '_query')) {
-            $sessionFilter = session()->get($this->getCacheKey() . '_query');
+        $sessionFilter = $this->sessionFilterInstance
+            ?? (session()->has($this->getCacheKey() . '_query')
+                ? session()->get($this->getCacheKey() . '_query')
+                : null);
 
-            if ($sessionFilter instanceof SessionFilter) {
-                $sessionFilter->getClosure()($query, $this);
+        if ($sessionFilter instanceof SessionFilter) {
+            $sessionFilter->getClosure()($query, $this);
 
-                $this->sessionFilter = [
-                    'name' => $sessionFilter->name,
-                ];
+            $this->sessionFilter = [
+                'name' => $sessionFilter->name,
+            ];
+            $this->sessionFilterInstance = $sessionFilter;
 
-                if (! $sessionFilter->loaded) {
-                    $this->userFilters = [];
-                    $sessionFilter->loaded = true;
+            if (! $sessionFilter->loaded) {
+                $this->userFilters = [];
+                $sessionFilter->loaded = true;
 
-                    session()->put($this->getCacheKey() . '_query', $sessionFilter);
-                }
+                session()->put($this->getCacheKey() . '_query', $sessionFilter);
             }
         }
     }

--- a/tests/Feature/SessionFilterSerializationTest.php
+++ b/tests/Feature/SessionFilterSerializationTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Database\Eloquent\Builder;
+use Livewire\Livewire;
+use TeamNiftyGmbH\DataTable\Helpers\SessionFilter;
+use Tests\Fixtures\Livewire\PostDataTable;
+use function Livewire\invade;
+
+beforeEach(function (): void {
+    $this->user = createTestUser();
+    $this->actingAs($this->user);
+});
+
+describe('SessionFilter survives serialization for queued exports', function (): void {
+    it('applies session filter from object after unserialization without session', function (): void {
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Published', 'is_published' => true]);
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Draft', 'is_published' => false]);
+
+        $component = Livewire::test(PostDataTable::class);
+        $instance = $component->instance();
+
+        SessionFilter::make(
+            $instance->getCacheKey(),
+            fn (Builder $query) => $query->where('is_published', true),
+            'Published Only',
+        )->store();
+
+        // Load data with session filter — table shows filtered results
+        $instance->loadData();
+        $data = $instance->getDataForTesting();
+        expect($data['total'])->toBe(1);
+        expect($data['data'][0]['title'])->toBe('Published');
+
+        // Simulate job context: serialize, clear session, unserialize
+        $serialized = serialize($instance);
+        session()->flush();
+
+        $unserialized = unserialize($serialized);
+
+        // buildSearch without session must still apply the filter
+        $query = invade($unserialized)->buildSearch();
+        $results = $query->get();
+
+        expect($results)->toHaveCount(1)
+            ->and($results->first()->title)->toBe('Published');
+    });
+
+    it('preserves session filter name after unserialization', function (): void {
+        $component = Livewire::test(PostDataTable::class);
+        $instance = $component->instance();
+
+        SessionFilter::make(
+            $instance->getCacheKey(),
+            fn (Builder $query) => $query->where('is_published', true),
+            'My Filter Name',
+        )->store();
+
+        $instance->loadData();
+        expect($instance->sessionFilter)->toBe(['name' => 'My Filter Name']);
+
+        $serialized = serialize($instance);
+        session()->flush();
+
+        $unserialized = unserialize($serialized);
+        expect($unserialized->sessionFilter)->toBe(['name' => 'My Filter Name']);
+    });
+});


### PR DESCRIPTION
## Summary
- Store `SessionFilter` on the DataTable instance (`sessionFilterInstance` property) in addition to the HTTP session
- `applySessionFilter()` now checks the instance property first, then falls back to the session
- Fixes exports running as queued jobs (`ExportDataTableJob`) not applying session filters because queued jobs have no access to the HTTP session
- `forgetSessionFilter()` clears both the session and the instance property