### PR TITLE
Add trait-based augmentItemArray hook

### DIFF
--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -188,6 +188,12 @@ trait BuildsQueries
             }
 
             $raw = $itemArray[$col];
+
+            // Skip columns that already have a display value (e.g. from trait augmentation hooks)
+            if (is_array($raw) && isset($raw['display'])) {
+                continue;
+            }
+
             $formatter = $formatters[$col] ?? null;
 
             if (! $formatter) {

--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -548,6 +548,14 @@ trait BuildsQueries
             : null;
 
         $this->augmentItemArray($itemArray, $item);
+
+        foreach (class_uses_recursive(static::class) as $trait) {
+            $method = 'augmentItemArray' . class_basename($trait);
+            if (method_exists($this, $method)) {
+                $this->$method($itemArray, $item);
+            }
+        }
+
         $this->applyFormatters($itemArray, $item, $rawArray);
 
         return $itemArray;


### PR DESCRIPTION
## Summary
- Add trait-based `augmentItemArray{TraitBaseName}()` hook in `itemToArray()`, following the existing `compileActions` convention
- Add display guard in `applyFormatters()` to skip columns that already have a `['display']` value from trait hooks

Enables traits on DataTable subclasses to inject custom cell content without conflicting with each other or with concrete class overrides of `augmentItemArray()`.