### PR TITLE
Apply elementFormatter to scalar values in ArrayFormatter

### DIFF
--- a/src/Formatters/ArrayFormatter.php
+++ b/src/Formatters/ArrayFormatter.php
@@ -17,7 +17,9 @@ class ArrayFormatter implements Formatter
         }
 
         if (! is_array($value)) {
-            return e((string) $value);
+            return $this->elementFormatter
+                ? $this->elementFormatter->format($value, $context)
+                : e((string) $value);
         }
 
         if (empty($value)) {

--- a/tests/Unit/Formatters/ArrayFormatterTest.php
+++ b/tests/Unit/Formatters/ArrayFormatterTest.php
@@ -144,6 +144,23 @@ describe('ArrayFormatter', function (): void {
             ->not->toContain('>null</span>');
     });
 
+    it('applies element formatter to scalar (non-array) value', function (): void {
+        $dateFormatter = new TeamNiftyGmbH\DataTable\Formatters\DateFormatter(mode: 'datetime');
+        $formatter = new ArrayFormatter(elementFormatter: $dateFormatter);
+
+        $result = $formatter->format('2026-04-28T00:00:00.000000Z');
+
+        expect($result)
+            ->not->toContain('2026-04-28T00:00:00')
+            ->toContain('28');
+    });
+
+    it('returns escaped string for scalar without element formatter', function (): void {
+        $formatter = new ArrayFormatter();
+
+        expect($formatter->format('plain string'))->toBe('plain string');
+    });
+
     it('without element formatter renders raw values in badges', function (): void {
         $formatter = new ArrayFormatter();
 


### PR DESCRIPTION
## Summary
- `ArrayFormatter` now delegates to `elementFormatter` for scalar (non-array) values
- Fixes datetime columns from HasMany/BelongsToMany relations displaying as raw ISO strings instead of formatted dates
- When a relation has a single record, `itemToArray` returns a scalar instead of an array, but the formatter was skipping the elementFormatter for scalars