### PR TITLE
Store SessionFilter in cache for JSON session compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         run: npm run build
 
       - name: Determine previous tag
-        run: echo "PREV_TAG=$(git describe --tags --abbrev=0 HEAD)" >> $GITHUB_ENV
+        run: echo "PREV_TAG=$(git tag --sort=-version:refname | head -1)" >> $GITHUB_ENV
 
       - name: Create release tag
         run: |

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -253,9 +253,18 @@ class DataTable extends Component
         // v2: kept for backwards compatibility but no-ops
     }
 
+    public function __serialize(): array
+    {
+        if (! $this->sessionFilterInstance) {
+            $this->sessionFilterInstance = SessionFilter::retrieve($this->getCacheKey());
+        }
+
+        return (array) $this;
+    }
+
     public function forgetSessionFilter(bool $loadData = false): void
     {
-        session()->forget($this->getCacheKey() . '_query');
+        SessionFilter::forget($this->getCacheKey());
         $this->sessionFilter = [];
         $this->sessionFilterInstance = null;
 

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -149,6 +149,15 @@ class DataTable extends Component
 
     private bool $dataLoadedThisRequest = false;
 
+    public function __serialize(): array
+    {
+        if (! $this->sessionFilterInstance) {
+            $this->sessionFilterInstance = SessionFilter::retrieve($this->getCacheKey());
+        }
+
+        return (array) $this;
+    }
+
     public function mount(): void
     {
         if (! $this->modelKeyName || ! $this->modelTable) {
@@ -251,15 +260,6 @@ class DataTable extends Component
     public function forceRender(): void
     {
         // v2: kept for backwards compatibility but no-ops
-    }
-
-    public function __serialize(): array
-    {
-        if (! $this->sessionFilterInstance) {
-            $this->sessionFilterInstance = SessionFilter::retrieve($this->getCacheKey());
-        }
-
-        return (array) $this;
     }
 
     public function forgetSessionFilter(bool $loadData = false): void

--- a/src/Helpers/SessionFilter.php
+++ b/src/Helpers/SessionFilter.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Support\Facades\Cache;
 use Laravel\SerializableClosure\SerializableClosure;
 use TeamNiftyGmbH\DataTable\DataTable;
+use Throwable;
 
 class SessionFilter
 {
@@ -19,9 +20,43 @@ class SessionFilter
         $this->setClosure($this->closure);
     }
 
+    public static function forget(string $dataTableCacheKey): void
+    {
+        Cache::forget(static::cacheKey($dataTableCacheKey));
+        session()->forget($dataTableCacheKey . '_query');
+    }
+
     public static function make(string|DataTable $dataTableCacheKey, Closure $closure, string $name): static
     {
         return new static($dataTableCacheKey, $closure, $name);
+    }
+
+    public static function retrieve(string $dataTableCacheKey): ?static
+    {
+        $cacheKey = static::cacheKey($dataTableCacheKey);
+
+        $raw = Cache::get($cacheKey);
+
+        if (! is_string($raw)) {
+            return null;
+        }
+
+        try {
+            $filter = unserialize($raw);
+
+            return $filter instanceof static ? $filter : null;
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    private static function cacheKey(string $dataTableCacheKey): string
+    {
+        $userKey = auth()->check()
+            ? auth()->user()->getMorphClass() . ':' . auth()->id()
+            : session()->getId();
+
+        return 'session_filter:' . $userKey . ':' . $dataTableCacheKey;
     }
 
     public function getClosure(): Closure
@@ -61,39 +96,5 @@ class SessionFilter
         Cache::put($cacheKey, serialize($this), now()->addHours(2));
 
         session()->put($this->dataTableCacheKey . '_query', true);
-    }
-
-    public static function retrieve(string $dataTableCacheKey): ?static
-    {
-        $cacheKey = static::cacheKey($dataTableCacheKey);
-
-        $raw = Cache::get($cacheKey);
-
-        if (! is_string($raw)) {
-            return null;
-        }
-
-        try {
-            $filter = unserialize($raw);
-
-            return $filter instanceof static ? $filter : null;
-        } catch (\Throwable) {
-            return null;
-        }
-    }
-
-    public static function forget(string $dataTableCacheKey): void
-    {
-        Cache::forget(static::cacheKey($dataTableCacheKey));
-        session()->forget($dataTableCacheKey . '_query');
-    }
-
-    private static function cacheKey(string $dataTableCacheKey): string
-    {
-        $userKey = auth()->check()
-            ? auth()->user()->getMorphClass() . ':' . auth()->id()
-            : session()->getId();
-
-        return 'session_filter:' . $userKey . ':' . $dataTableCacheKey;
     }
 }

--- a/src/Helpers/SessionFilter.php
+++ b/src/Helpers/SessionFilter.php
@@ -3,11 +3,11 @@
 namespace TeamNiftyGmbH\DataTable\Helpers;
 
 use Closure;
+use Illuminate\Support\Facades\Cache;
 use Laravel\SerializableClosure\SerializableClosure;
-use Serializable;
 use TeamNiftyGmbH\DataTable\DataTable;
 
-class SessionFilter implements Serializable
+class SessionFilter
 {
     public function __construct(
         public string|DataTable|null $dataTableCacheKey = null,
@@ -19,24 +19,6 @@ class SessionFilter implements Serializable
         $this->setClosure($this->closure);
     }
 
-    public function __serialize(): array
-    {
-        return [
-            'dataTableCacheKey' => data_get($this, 'dataTableCacheKey'),
-            'closure' => data_get($this, 'closure'),
-            'name' => data_get($this, 'name'),
-            'loaded' => data_get($this, 'loaded'),
-        ];
-    }
-
-    public function __unserialize(array $data): void
-    {
-        $this->dataTableCacheKey = data_get($data, 'dataTableCacheKey');
-        $this->closure = data_get($data, 'closure');
-        $this->name = data_get($data, 'name');
-        $this->loaded = data_get($data, 'loaded', false);
-    }
-
     public static function make(string|DataTable $dataTableCacheKey, Closure $closure, string $name): static
     {
         return new static($dataTableCacheKey, $closure, $name);
@@ -45,11 +27,6 @@ class SessionFilter implements Serializable
     public function getClosure(): Closure
     {
         return $this->closure->getClosure();
-    }
-
-    public function serialize(): string
-    {
-        return serialize($this->__serialize());
     }
 
     public function setClosure(callable $closure): static
@@ -79,15 +56,44 @@ class SessionFilter implements Serializable
 
     public function store(): void
     {
-        session()
-            ->put(
-                $this->dataTableCacheKey . '_query',
-                $this
-            );
+        $cacheKey = static::cacheKey($this->dataTableCacheKey);
+
+        Cache::put($cacheKey, serialize($this), now()->addHours(2));
+
+        session()->put($this->dataTableCacheKey . '_query', true);
     }
 
-    public function unserialize(string $data): void
+    public static function retrieve(string $dataTableCacheKey): ?static
     {
-        $this->__unserialize(unserialize($data));
+        $cacheKey = static::cacheKey($dataTableCacheKey);
+
+        $raw = Cache::get($cacheKey);
+
+        if (! is_string($raw)) {
+            return null;
+        }
+
+        try {
+            $filter = unserialize($raw);
+
+            return $filter instanceof static ? $filter : null;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    public static function forget(string $dataTableCacheKey): void
+    {
+        Cache::forget(static::cacheKey($dataTableCacheKey));
+        session()->forget($dataTableCacheKey . '_query');
+    }
+
+    private static function cacheKey(string $dataTableCacheKey): string
+    {
+        $userKey = auth()->check()
+            ? auth()->user()->getMorphClass() . ':' . auth()->id()
+            : session()->getId();
+
+        return 'session_filter:' . $userKey . ':' . $dataTableCacheKey;
     }
 }

--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -820,9 +820,7 @@ trait BuildsQueries
     private function applySessionFilter(Builder $query): void
     {
         $sessionFilter = $this->sessionFilterInstance
-            ?? (session()->has($this->getCacheKey() . '_query')
-                ? session()->get($this->getCacheKey() . '_query')
-                : null);
+            ?? SessionFilter::retrieve($this->getCacheKey());
 
         if ($sessionFilter instanceof SessionFilter) {
             $sessionFilter->getClosure()($query, $this);
@@ -836,7 +834,7 @@ trait BuildsQueries
                 $this->userFilters = [];
                 $sessionFilter->loaded = true;
 
-                session()->put($this->getCacheKey() . '_query', $sessionFilter);
+                $sessionFilter->store();
             }
         }
     }

--- a/tests/Feature/BuildsQueriesTest.php
+++ b/tests/Feature/BuildsQueriesTest.php
@@ -1418,15 +1418,14 @@ describe('applySessionFilter', function (): void {
         createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Session Match', 'price' => 10]);
         createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Session Skip', 'price' => 999]);
 
-        // Set session filter BEFORE mounting the component
-        $cacheKey = PostDataTable::class . '_query';
-        $sessionFilter = new TeamNiftyGmbH\DataTable\Helpers\SessionFilter(
-            'test-filter',
+        // Store session filter via cache BEFORE mounting the component
+        TeamNiftyGmbH\DataTable\Helpers\SessionFilter::make(
+            PostDataTable::class,
             function ($query): void {
                 $query->where('title', 'Session Match');
-            }
-        );
-        session()->put($cacheKey, $sessionFilter);
+            },
+            'test-filter'
+        )->store();
 
         $component = Livewire::test(PostDataTable::class);
 
@@ -1434,7 +1433,7 @@ describe('applySessionFilter', function (): void {
         expect($data['total'])->toBe(1);
         expect($data['data'][0]['title'])->toBe('Session Match');
 
-        session()->forget($cacheKey);
+        TeamNiftyGmbH\DataTable\Helpers\SessionFilter::forget(PostDataTable::class);
     });
 
     it('does not crash when no session filter is present', function (): void {
@@ -1450,21 +1449,20 @@ describe('applySessionFilter', function (): void {
     it('clears userFilters on first load of session filter', function (): void {
         createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Session Post']);
 
-        $cacheKey = PostDataTable::class . '_query';
-        $sessionFilter = new TeamNiftyGmbH\DataTable\Helpers\SessionFilter(
-            'clearing-filter',
+        TeamNiftyGmbH\DataTable\Helpers\SessionFilter::make(
+            PostDataTable::class,
             function ($query): void {
                 $query->where('title', 'like', '%Session%');
-            }
-        );
-        session()->put($cacheKey, $sessionFilter);
+            },
+            'clearing-filter'
+        )->store();
 
         $component = Livewire::test(PostDataTable::class);
 
         // After initial load, userFilters should be empty (cleared by session filter)
         expect($component->get('userFilters'))->toBe([]);
 
-        session()->forget($cacheKey);
+        TeamNiftyGmbH\DataTable\Helpers\SessionFilter::forget(PostDataTable::class);
     });
 });
 
@@ -1867,57 +1865,54 @@ describe('applySessionFilter additional coverage', function (): void {
     it('sets sessionFilter name from SessionFilter object', function (): void {
         createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Session Named']);
 
-        $cacheKey = PostDataTable::class . '_query';
-        $sessionFilter = new TeamNiftyGmbH\DataTable\Helpers\SessionFilter(
-            'named-filter',
+        TeamNiftyGmbH\DataTable\Helpers\SessionFilter::make(
+            PostDataTable::class,
             function ($query): void {
                 $query->where('title', 'like', '%Session%');
-            }
-        );
-        $sessionFilter->setName('My Named Filter');
-        session()->put($cacheKey, $sessionFilter);
+            },
+            'My Named Filter'
+        )->store();
 
         $component = Livewire::test(PostDataTable::class);
 
         expect($component->get('sessionFilter'))->toBe(['name' => 'My Named Filter']);
 
-        session()->forget($cacheKey);
+        TeamNiftyGmbH\DataTable\Helpers\SessionFilter::forget(PostDataTable::class);
     });
 
     it('marks session filter as loaded after first use', function (): void {
         createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Loaded Check']);
 
-        $cacheKey = PostDataTable::class . '_query';
-        $sessionFilter = new TeamNiftyGmbH\DataTable\Helpers\SessionFilter(
-            'loaded-check',
+        TeamNiftyGmbH\DataTable\Helpers\SessionFilter::make(
+            PostDataTable::class,
             function ($query): void {
                 $query->where('title', 'like', '%Loaded%');
-            }
-        );
-        session()->put($cacheKey, $sessionFilter);
+            },
+            'loaded-check'
+        )->store();
 
         $component = Livewire::test(PostDataTable::class);
 
-        // After first load, the session filter should be marked as loaded
-        $storedFilter = session()->get($cacheKey);
+        // After first load, the session filter should be marked as loaded in cache
+        $storedFilter = TeamNiftyGmbH\DataTable\Helpers\SessionFilter::retrieve(PostDataTable::class);
         expect($storedFilter->loaded)->toBeTrue();
 
-        session()->forget($cacheKey);
+        TeamNiftyGmbH\DataTable\Helpers\SessionFilter::forget(PostDataTable::class);
     });
 
     it('does not clear userFilters on second load of session filter', function (): void {
         createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Second Load']);
 
-        $cacheKey = PostDataTable::class . '_query';
-        $sessionFilter = new TeamNiftyGmbH\DataTable\Helpers\SessionFilter(
-            'second-load',
+        $sessionFilter = TeamNiftyGmbH\DataTable\Helpers\SessionFilter::make(
+            PostDataTable::class,
             function ($query): void {
                 $query->where('title', 'like', '%Second%');
-            }
+            },
+            'second-load'
         );
         // Pre-mark as loaded
         $sessionFilter->loaded = true;
-        session()->put($cacheKey, $sessionFilter);
+        $sessionFilter->store();
 
         $component = Livewire::test(PostDataTable::class);
 
@@ -1926,7 +1921,7 @@ describe('applySessionFilter additional coverage', function (): void {
         $data = $component->instance()->getDataForTesting();
         expect($data)->toBeArray();
 
-        session()->forget($cacheKey);
+        TeamNiftyGmbH\DataTable\Helpers\SessionFilter::forget(PostDataTable::class);
     });
 });
 

--- a/tests/Feature/SessionFilterSerializationTest.php
+++ b/tests/Feature/SessionFilterSerializationTest.php
@@ -45,6 +45,36 @@ describe('SessionFilter survives serialization for queued exports', function ():
             ->and($results->first()->title)->toBe('Published');
     });
 
+    it('captures session filter during serialize even when instance property is null', function (): void {
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Published', 'is_published' => true]);
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Draft', 'is_published' => false]);
+
+        $component = Livewire::test(PostDataTable::class);
+        $instance = $component->instance();
+
+        // Store filter in session but do NOT call loadData — simulates
+        // Livewire rehydration where sessionFilterInstance is null
+        SessionFilter::make(
+            $instance->getCacheKey(),
+            fn (Builder $query) => $query->where('is_published', true),
+            'Published Only',
+        )->store();
+
+        // sessionFilterInstance is null (not populated by applySessionFilter)
+        expect(invade($instance)->sessionFilterInstance)->toBeNull();
+
+        // __serialize grabs it from the session
+        $serialized = serialize($instance);
+        session()->flush();
+
+        $unserialized = unserialize($serialized);
+        $query = invade($unserialized)->buildSearch();
+        $results = $query->get();
+
+        expect($results)->toHaveCount(1)
+            ->and($results->first()->title)->toBe('Published');
+    });
+
     it('preserves session filter name after unserialization', function (): void {
         $component = Livewire::test(PostDataTable::class);
         $instance = $component->instance();

--- a/tests/Feature/SessionFilterTest.php
+++ b/tests/Feature/SessionFilterTest.php
@@ -19,8 +19,10 @@ describe('SessionFilter Construction', function (): void {
             ->and($filter->dataTableCacheKey)->toBe('test-key');
     });
 
-    it('implements the Serializable interface', function (): void {
-        expect(SessionFilter::class)->toImplement(Serializable::class);
+    it('is a plain class without Serializable interface', function (): void {
+        $filter = SessionFilter::make('test', fn (Builder $query) => $query, 'Test');
+
+        expect($filter)->toBeInstanceOf(SessionFilter::class);
     });
 
     it('wraps closure in SerializableClosure on construction', function (): void {
@@ -117,62 +119,40 @@ describe('SessionFilter Serialization', function (): void {
         expect($serialized)->toBeString()->not->toBeEmpty();
     });
 
-    //    it('can be unserialized back to SessionFilter', function (): void {
-    //        $filter = SessionFilter::make(
-    //            'round-trip-key',
-    //            fn (Builder $q) => $q->where('active', true),
-    //            'RoundTrip'
-    //        );
-    //
-    //        $unserialized = unserialize(serialize($filter));
-    //
-    //        expect($unserialized)
-    //            ->toBeInstanceOf(SessionFilter::class)
-    //            ->and($unserialized->name)->toBe('RoundTrip');
-    //    });
+    it('can be unserialized back to SessionFilter', function (): void {
+        $filter = SessionFilter::make(
+            'round-trip-key',
+            fn (Builder $q) => $q->where('active', true),
+            'RoundTrip'
+        );
 
-    //    it('preserves closure after round-trip serialization', function (): void {
-    //        $filter = SessionFilter::make(
-    //            'closure-key',
-    //            fn (Builder $q) => $q->where('status', 'draft'),
-    //            'Draft'
-    //        );
-    //
-    //        $unserialized = unserialize(serialize($filter));
-    //
-    //        expect($unserialized->getClosure())->toBeInstanceOf(Closure::class);
-    //    });
+        $unserialized = unserialize(serialize($filter));
 
-    //    it('preserves loaded state after serialization', function (): void {
-    //        $filter = SessionFilter::make('key', fn (Builder $q) => $q, 'Test');
-    //        $filter->loaded = true;
-    //
-    //        $unserialized = unserialize(serialize($filter));
-    //
-    //        expect($unserialized->loaded)->toBeTrue();
-    //    });
-
-    // Skipped: SessionFilter::unserialize() has a null-type bug in setDataTableCacheKey
-
-    it('supports the serialize method directly', function (): void {
-        $filter = SessionFilter::make('direct-key', fn (Builder $q) => $q, 'Direct');
-
-        $serialized = $filter->serialize();
-
-        expect($serialized)->toBeString()->not->toBeEmpty();
+        expect($unserialized)
+            ->toBeInstanceOf(SessionFilter::class)
+            ->and($unserialized->name)->toBe('RoundTrip');
     });
 
-    //    it('supports the unserialize method directly', function (): void {
-    //        $filter = SessionFilter::make('unsrz-key', fn (Builder $q) => $q, 'Unserialize');
-    //
-    //        $serialized = $filter->serialize();
-    //
-    //        $newFilter = new SessionFilter();
-    //        $newFilter->unserialize($serialized);
-    //
-    //        expect($newFilter->name)->toBe('Unserialize')
-    //            ->and($newFilter->dataTableCacheKey)->toBe('unsrz-key');
-    //    });
+    it('preserves closure after round-trip serialization', function (): void {
+        $filter = SessionFilter::make(
+            'closure-key',
+            fn (Builder $q) => $q->where('status', 'draft'),
+            'Draft'
+        );
+
+        $unserialized = unserialize(serialize($filter));
+
+        expect($unserialized->getClosure())->toBeInstanceOf(Closure::class);
+    });
+
+    it('preserves loaded state after serialization', function (): void {
+        $filter = SessionFilter::make('key', fn (Builder $q) => $q, 'Test');
+        $filter->loaded = true;
+
+        $unserialized = unserialize(serialize($filter));
+
+        expect($unserialized->loaded)->toBeTrue();
+    });
 });
 
 describe('SessionFilter Session Storage', function (): void {
@@ -188,19 +168,21 @@ describe('SessionFilter Session Storage', function (): void {
         expect(session()->has('store-key_query'))->toBeTrue();
     });
 
-    it('stores itself as the session value', function (): void {
+    it('stores itself in cache and sets session marker', function (): void {
         $filter = SessionFilter::make('value-key', fn (Builder $q) => $q, 'Value');
 
         $filter->store();
 
-        $stored = session()->get('value-key_query');
+        expect(session()->get('value-key_query'))->toBeTrue();
+
+        $stored = SessionFilter::retrieve('value-key');
 
         expect($stored)
             ->toBeInstanceOf(SessionFilter::class)
             ->and($stored->name)->toBe('Value');
     });
 
-    it('can be retrieved from session after storing', function (): void {
+    it('can be retrieved from cache after storing', function (): void {
         $filter = SessionFilter::make(
             'retrieve-key',
             fn (Builder $q) => $q->where('active', true),
@@ -208,7 +190,7 @@ describe('SessionFilter Session Storage', function (): void {
         );
         $filter->store();
 
-        $retrieved = session()->get('retrieve-key_query');
+        $retrieved = SessionFilter::retrieve('retrieve-key');
 
         expect($retrieved->name)->toBe('Retrievable')
             ->and($retrieved->dataTableCacheKey)->toBe('retrieve-key');
@@ -247,21 +229,21 @@ describe('SessionFilter with Real Query Execution', function (): void {
             ->and($results->first()->title)->toBe('Visible Post');
     });
 
-    //    it('closure survives serialization and still filters correctly', function (): void {
-    //        $filter = SessionFilter::make(
-    //            'serial-query',
-    //            fn (Builder $q) => $q->where('is_published', false),
-    //            'Drafts'
-    //        );
-    //
-    //        $unserialized = unserialize(serialize($filter));
-    //        $closure = $unserialized->getClosure();
-    //        $query = Post::query();
-    //        $closure($query);
-    //
-    //        $results = $query->get();
-    //
-    //        expect($results)->toHaveCount(1)
-    //            ->and($results->first()->title)->toBe('Hidden Post');
-    //    });
+    it('closure survives serialization and still filters correctly', function (): void {
+        $filter = SessionFilter::make(
+            'serial-query',
+            fn (Builder $q) => $q->where('is_published', false),
+            'Drafts'
+        );
+
+        $unserialized = unserialize(serialize($filter));
+        $closure = $unserialized->getClosure();
+        $query = Post::query();
+        $closure($query);
+
+        $results = $query->get();
+
+        expect($results)->toHaveCount(1)
+            ->and($results->first()->title)->toBe('Hidden Post');
+    });
 });

--- a/tests/Feature/StoresSettingsTest.php
+++ b/tests/Feature/StoresSettingsTest.php
@@ -36,7 +36,9 @@ describe('ensureAuthHasTrait', function (): void {
             'password' => bcrypt('password'),
         ]);
 
+        Auth::shouldReceive('check')->andReturn(true);
         Auth::shouldReceive('user')->andReturn($plainUser);
+        Auth::shouldReceive('id')->andReturn(9999);
 
         $component = Livewire::test(PostDataTable::class);
 

--- a/tests/Unit/Helpers/SessionFilterTest.php
+++ b/tests/Unit/Helpers/SessionFilterTest.php
@@ -19,8 +19,10 @@ describe('SessionFilter', function (): void {
             ->and($filter->dataTableCacheKey)->toBe('test-datatable');
     });
 
-    it('implements Serializable interface', function (): void {
-        expect(SessionFilter::class)->toImplement(Serializable::class);
+    it('is a plain class without Serializable interface', function (): void {
+        $filter = SessionFilter::make('test', fn (Builder $query) => $query, 'Test');
+
+        expect($filter)->toBeInstanceOf(SessionFilter::class);
     });
 
     it('can set datatable cache key from string', function (): void {
@@ -154,7 +156,7 @@ describe('SessionFilter Session Storage', function (): void {
         expect(session()->has('post-datatable_query'))->toBeTrue();
     });
 
-    it('stores with correct session key', function (): void {
+    it('stores with correct session marker key', function (): void {
         $filter = SessionFilter::make(
             'custom-key',
             fn (Builder $query) => $query,
@@ -163,10 +165,10 @@ describe('SessionFilter Session Storage', function (): void {
 
         $filter->store();
 
-        expect(session()->get('custom-key_query'))->toBeInstanceOf(SessionFilter::class);
+        expect(session()->get('custom-key_query'))->toBeTrue();
     });
 
-    it('can retrieve stored filter from session', function (): void {
+    it('can retrieve stored filter from cache', function (): void {
         $filter = SessionFilter::make(
             'retrievable-key',
             fn (Builder $query) => $query->where('active', true),
@@ -175,7 +177,7 @@ describe('SessionFilter Session Storage', function (): void {
 
         $filter->store();
 
-        $retrieved = session()->get('retrievable-key_query');
+        $retrieved = SessionFilter::retrieve('retrievable-key');
 
         expect($retrieved)
             ->toBeInstanceOf(SessionFilter::class)
@@ -219,20 +221,21 @@ describe('SessionFilter with Real Query', function (): void {
     });
 });
 
-describe('SessionFilter __serialize and __unserialize', function (): void {
-    it('__serialize returns array with all properties', function (): void {
+describe('SessionFilter native serialize and unserialize', function (): void {
+    it('serialize preserves all properties', function (): void {
         $filter = SessionFilter::make('test-key', fn (Builder $query) => $query, 'Test Name');
-        $data = $filter->__serialize();
 
-        expect($data)
-            ->toBeArray()
-            ->toHaveKeys(['dataTableCacheKey', 'closure', 'name', 'loaded']);
-        expect($data['dataTableCacheKey'])->toBe('test-key');
-        expect($data['name'])->toBe('Test Name');
-        expect($data['loaded'])->toBeFalse();
+        $serialized = serialize($filter);
+        $restored = unserialize($serialized);
+
+        expect($restored)
+            ->toBeInstanceOf(SessionFilter::class);
+        expect($restored->dataTableCacheKey)->toBe('test-key');
+        expect($restored->name)->toBe('Test Name');
+        expect($restored->loaded)->toBeFalse();
     });
 
-    it('__unserialize restores all properties from array', function (): void {
+    it('unserialize restores all properties', function (): void {
         $filter = SessionFilter::make('original', fn (Builder $query) => $query, 'Original');
         $filter->loaded = true;
 
@@ -244,19 +247,19 @@ describe('SessionFilter __serialize and __unserialize', function (): void {
         expect($restored->loaded)->toBeTrue();
     });
 
-    it('serialize method returns string representation', function (): void {
+    it('serialize returns a string representation', function (): void {
         $filter = SessionFilter::make('test', fn (Builder $query) => $query, 'Filter');
 
-        $serialized = $filter->serialize();
+        $serialized = serialize($filter);
 
         expect($serialized)->toBeString();
-        $unserialized = unserialize($serialized);
-        expect($unserialized)->toBeArray()
-            ->toHaveKey('name')
-            ->toHaveKey('dataTableCacheKey');
+        $restored = unserialize($serialized);
+        expect($restored)->toBeInstanceOf(SessionFilter::class)
+            ->and($restored->name)->toBe('Filter')
+            ->and($restored->dataTableCacheKey)->toBe('test');
     });
 
-    it('unserialize method restores from string', function (): void {
+    it('unserialize restores from serialized string', function (): void {
         $filter = SessionFilter::make('from-str', fn (Builder $query) => $query, 'StringFilter');
 
         $serialized = serialize($filter);
@@ -266,7 +269,7 @@ describe('SessionFilter __serialize and __unserialize', function (): void {
         expect($restored->dataTableCacheKey)->toBe('from-str');
     });
 
-    it('loaded defaults to false in unserialized data without loaded key', function (): void {
+    it('loaded defaults to false after round-trip', function (): void {
         $filter = SessionFilter::make('key', fn (Builder $query) => $query, 'test');
         $filter->loaded = false;
 
@@ -299,24 +302,18 @@ describe('SessionFilter constructor edge cases', function (): void {
     });
 });
 
-describe('SessionFilter unserialize method', function (): void {
-    it('restores from string via unserialize method', function (): void {
+describe('SessionFilter round-trip via store and retrieve', function (): void {
+    it('restores from cache via retrieve method', function (): void {
         $filter = SessionFilter::make('test-key', fn (Builder $query) => $query, 'MyFilter');
         $filter->loaded = true;
 
-        $serializedInner = $filter->serialize();
+        $filter->store();
 
-        $newFilter = new SessionFilter(
-            dataTableCacheKey: 'placeholder',
-            closure: fn () => null,
-            name: 'placeholder'
-        );
+        $restored = SessionFilter::retrieve('test-key');
 
-        $newFilter->unserialize($serializedInner);
-
-        expect($newFilter->dataTableCacheKey)->toBe('test-key');
-        expect($newFilter->name)->toBe('MyFilter');
-        expect($newFilter->loaded)->toBeTrue();
+        expect($restored->dataTableCacheKey)->toBe('test-key');
+        expect($restored->name)->toBe('MyFilter');
+        expect($restored->loaded)->toBeTrue();
     });
 });
 

--- a/tests/Unit/SessionFilterTest.php
+++ b/tests/Unit/SessionFilterTest.php
@@ -79,7 +79,7 @@ describe('SessionFilter', function (): void {
             ->and($unserialized->loaded)->toBeFalse();
     });
 
-    it('can store to session', function (): void {
+    it('can store to cache and sets session marker', function (): void {
         $filter = SessionFilter::make(
             dataTableCacheKey: 'session-test',
             closure: fn (Builder $query) => $query,
@@ -89,7 +89,13 @@ describe('SessionFilter', function (): void {
         $filter->store();
 
         expect(session()->has('session-test_query'))->toBeTrue();
-        expect(session()->get('session-test_query'))->toBeInstanceOf(SessionFilter::class);
+        expect(session()->get('session-test_query'))->toBeTrue();
+
+        $retrieved = SessionFilter::retrieve('session-test');
+
+        expect($retrieved)
+            ->toBeInstanceOf(SessionFilter::class)
+            ->and($retrieved->name)->toBe('Session Test');
     });
 
     it('can set closure', function (): void {


### PR DESCRIPTION
## Summary
- Move SessionFilter storage from session to cache (scoped by user ID)
- Use PHP `serialize()`/`unserialize()` for the closure data instead of storing objects directly
- Fixes SessionFilter not working with Laravel 13's JSON session serialization (`session.serialization: json`)
- `__serialize` on DataTable captures the filter from cache during HTTP context for queued exports
- Fix release workflow: use `git tag --sort` instead of `git describe` to find previous tag

## Verified via Playwright
- Dashboard → Ausstehend widget → click "Anzeigen" → Orders list shows 22 filtered results
- Export from filtered list produces 22 rows (not 10774)