### PR TITLE
fix: resolve relation path to model class in loadSlug on cache miss

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "laravel/pint": "^1.0",
         "laravel/scout": "^10.0",
-        "nunomaduro/collision": "^8.5",
+        "nunomaduro/collision": "^8.5 <8.9.2",
         "orchestra/testbench": "^10.0",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-browser": "^4.0",

--- a/src/Traits/DataTables/SupportsRelations.php
+++ b/src/Traits/DataTables/SupportsRelations.php
@@ -162,7 +162,18 @@ trait SupportsRelations
         $data = Cache::get('relation-tree-widget.' . ($path ?? $this->getModel()));
 
         if (is_null($data)) {
-            $this->loadRelation($path ?? $this->getModel());
+            if ($path) {
+                $this->loadedPath = null;
+                $currentModel = $this->getModel();
+
+                foreach (explode('.', $path) as $segment) {
+                    $currentModel = get_class(app($currentModel)->{$segment}()->getRelated());
+                    $this->loadRelation($currentModel, $segment);
+                }
+            } else {
+                $this->loadRelation($this->getModel());
+            }
+
             $data = Cache::get('relation-tree-widget.' . ($path ?? $this->getModel()));
         }
 

--- a/tests/Feature/SupportsRelationsTest.php
+++ b/tests/Feature/SupportsRelationsTest.php
@@ -866,6 +866,36 @@ describe('SupportsRelations', function (): void {
             expect($result['cols'])->toBeArray()->not->toBeEmpty();
             expect($result['relations'])->toBeArray();
         });
+
+        it('resolves relation path to model class on cache miss', function (): void {
+            Cache::flush();
+
+            $component = Livewire::test(PostDataTable::class);
+
+            // loadSlug with a relation name should resolve the relation
+            // to its model class, not pass the relation name as a class name
+            $result = $component->instance()->loadSlug('user');
+
+            expect($result['cols'])->toBeArray()->not->toBeEmpty();
+            expect($result['relations'])->toBeArray();
+            expect($result['displayPath'])->toBeArray()->not->toBeEmpty();
+            expect($result['displayPath'][0]['value'])->toBe('user');
+        });
+
+        it('resolves nested relation path on cache miss', function (): void {
+            Cache::flush();
+
+            $component = Livewire::test(PostDataTable::class);
+
+            // loadSlug with a nested relation path should walk each segment
+            $result = $component->instance()->loadSlug('user.posts');
+
+            expect($result['cols'])->toBeArray()->not->toBeEmpty();
+            expect($result['relations'])->toBeArray();
+            expect($result['displayPath'])->toHaveCount(2);
+            expect($result['displayPath'][0]['value'])->toBe('user');
+            expect($result['displayPath'][1]['value'])->toBe('user.posts');
+        });
     });
 
     describe('addDynamicJoin with HasMany relation', function (): void {


### PR DESCRIPTION
## Summary
- `loadSlug` passed the relation name (e.g. `electronicRailcar`) directly to `loadRelation` as if it were a model class name, causing `BindingResolutionException` when the cache was empty
- Now resolves the relation path by walking each segment from the base model to get the actual related model class before calling `loadRelation`
- Adds tests for single and nested relation path resolution on cache miss