### PR TITLE
feat: add DurationFormatter for millisecond duration columns

### DIFF
--- a/src/Formatters/DurationFormatter.php
+++ b/src/Formatters/DurationFormatter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace TeamNiftyGmbH\DataTable\Formatters;
+
+use TeamNiftyGmbH\DataTable\Formatters\Contracts\Formatter;
+
+class DurationFormatter implements Formatter
+{
+    public function __construct(public readonly bool $showSeconds = false) {}
+
+    public function format(mixed $value, array $context = []): string
+    {
+        if (is_null($value)) {
+            return '';
+        }
+
+        $ms = (int) $value;
+        $negative = $ms < 0;
+        $ms = abs($ms);
+
+        $totalSeconds = intdiv($ms, 1000);
+        $hours = intdiv($totalSeconds, 3600);
+        $minutes = intdiv($totalSeconds % 3600, 60);
+        $seconds = $totalSeconds % 60;
+
+        $formatted = sprintf('%02d:%02d', $hours, $minutes);
+
+        if ($this->showSeconds) {
+            $formatted .= sprintf(':%02d', $seconds);
+        }
+
+        return $negative ? '-' . $formatted : $formatted;
+    }
+}

--- a/src/Formatters/FormatterRegistry.php
+++ b/src/Formatters/FormatterRegistry.php
@@ -122,6 +122,8 @@ class FormatterRegistry
             'url', 'link' => new LinkFormatter(),
             'relativetime' => new DateFormatter(mode: 'relative'),
             'time' => new DateFormatter(mode: 'time'),
+            'duration' => new DurationFormatter(),
+            'duration:seconds' => new DurationFormatter(showSeconds: true),
             'enum' => new EnumFormatter(),
             default => $this->isEnum($castClass) ? new EnumFormatter($castClass) : new StringFormatter(),
         };

--- a/tests/Unit/Formatters/DurationFormatterTest.php
+++ b/tests/Unit/Formatters/DurationFormatterTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use TeamNiftyGmbH\DataTable\Formatters\DurationFormatter;
+
+describe('DurationFormatter', function (): void {
+    it('returns empty string for null', function (): void {
+        $formatter = new DurationFormatter();
+
+        expect($formatter->format(null))->toBe('');
+    });
+
+    it('formats zero milliseconds', function (): void {
+        $formatter = new DurationFormatter();
+
+        expect($formatter->format(0))->toBe('00:00');
+    });
+
+    it('formats one hour in milliseconds', function (): void {
+        $formatter = new DurationFormatter();
+
+        expect($formatter->format(3600000))->toBe('01:00');
+    });
+
+    it('formats hours and minutes', function (): void {
+        $formatter = new DurationFormatter();
+
+        // 2h 30m = 9_000_000ms
+        expect($formatter->format(9000000))->toBe('02:30');
+    });
+
+    it('formats minutes only', function (): void {
+        $formatter = new DurationFormatter();
+
+        // 45m = 2_700_000ms
+        expect($formatter->format(2700000))->toBe('00:45');
+    });
+
+    it('formats with seconds when enabled', function (): void {
+        $formatter = new DurationFormatter(showSeconds: true);
+
+        // 1h 30m 15s = 5_415_000ms
+        expect($formatter->format(5415000))->toBe('01:30:15');
+    });
+
+    it('formats negative duration', function (): void {
+        $formatter = new DurationFormatter();
+
+        expect($formatter->format(-3600000))->toBe('-01:00');
+    });
+
+    it('handles string numeric values', function (): void {
+        $formatter = new DurationFormatter();
+
+        expect($formatter->format('7200000'))->toBe('02:00');
+    });
+
+    it('formats large durations beyond 24 hours', function (): void {
+        $formatter = new DurationFormatter();
+
+        // 25h = 90_000_000ms
+        expect($formatter->format(90000000))->toBe('25:00');
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `DurationFormatter` that converts millisecond values to `HH:MM` (or `HH:MM:SS` with `showSeconds: true`)
- Registered as `'duration'` and `'duration:seconds'` in `FormatterRegistry`
- Fixes columns like `total_time_ms` being incorrectly formatted by the `'time'` formatter, which interprets them as Unix timestamps via `Carbon::createFromTimestamp()`