### PR TITLE
fix: forward cellAttributes to table cells and preserve HtmlString values

### DIFF
--- a/resources/views/components/layouts/partials/table-row.blade.php
+++ b/resources/views/components/layouts/partials/table-row.blade.php
@@ -49,9 +49,15 @@
         ></td>
     @endif
     @foreach ($enabledCols as $col)
+        @php
+            $cellAttrClasses = trim(
+                $cellAttributes->get('class', '') . ' '
+                . (preg_match("/^'([^']*)'$/", $cellAttributes->get('x-bind:class', ''), $m) ? $m[1] : '')
+            );
+        @endphp
         <x-tall-datatables::table.cell
             :use-wire-navigate="$useWireNavigate"
-            :class="in_array($col, $this->stickyCols) ? 'sticky left-0 border-r bg-white dark:bg-secondary-800 dark:text-gray-50' : ''"
+            :class="implode(' ', array_filter([in_array($col, $this->stickyCols) ? 'sticky left-0 border-r bg-white dark:bg-secondary-800 dark:text-gray-50' : '', $cellAttrClasses]))"
             :style="in_array($col, $this->stickyCols) ? 'z-index: 2' : ''"
             :href="(($allowSoftDeletes && ($record['deleted_at'] ?? null)) ? null : ($record['href'] ?? null))"
         >

--- a/resources/views/components/table/cell.blade.php
+++ b/resources/views/components/table/cell.blade.php
@@ -6,9 +6,14 @@
     $hasStaticHref = $href !== null;
     $hasDynamicHref = $attributes->has('x-bind:href');
     $dynamicHrefExpr = $hasDynamicHref ? $attributes->get('x-bind:href') : 'false';
+    $hasWhitespaceOverride = str_contains($attributes->get('class', ''), 'whitespace-') || str_contains($attributes->get('x-bind:class', ''), 'whitespace-');
+    $defaultClasses = 'border-b border-gray-100 dark:border-secondary-700/50 text-sm p-0';
+    if (! $hasWhitespaceOverride) {
+        $defaultClasses .= ' whitespace-nowrap max-w-xs overflow-hidden text-ellipsis';
+    }
 @endphp
 <td
-    {{ $attributes->only(['class', 'x-bind:class', 'x-bind:style'])->merge(['class' => 'border-b border-gray-100 dark:border-secondary-700/50 whitespace-nowrap max-w-xs overflow-hidden text-ellipsis text-sm p-0']) }}
+    {{ $attributes->only(['class', 'x-bind:class', 'x-bind:style'])->merge(['class' => $defaultClasses]) }}
 >
     @if($hasStaticHref)
         <a

--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -13,6 +13,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 use Laravel\Scout\Searchable;
 use TeamNiftyGmbH\DataTable\Contracts\InteractsWithDataTables;
@@ -191,6 +192,13 @@ trait BuildsQueries
 
             // Skip columns that already have a display value (e.g. from trait augmentation hooks)
             if (is_array($raw) && isset($raw['display'])) {
+                continue;
+            }
+
+            // Preserve HtmlString values — they contain intentional, safe HTML
+            if ($raw instanceof HtmlString) {
+                $itemArray[$col] = ['raw' => strip_tags($raw->toHtml()), 'display' => $raw->toHtml()];
+
                 continue;
             }
 
@@ -468,6 +476,13 @@ trait BuildsQueries
 
                         // Skip already formatted values
                         if (is_array($itemArray[$col]) && isset($itemArray[$col]['display'])) {
+                            continue;
+                        }
+
+                        // Preserve HtmlString values — they contain intentional, safe HTML
+                        if ($itemArray[$col] instanceof HtmlString) {
+                            $itemArray[$col] = ['raw' => strip_tags($itemArray[$col]->toHtml()), 'display' => $itemArray[$col]->toHtml()];
+
                             continue;
                         }
 

--- a/tests/Feature/CellAttributesTest.php
+++ b/tests/Feature/CellAttributesTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Livewire\Livewire;
+use Tests\Fixtures\Livewire\CellAttributesPostDataTable;
+use Tests\Fixtures\Livewire\PostDataTable;
+
+beforeEach(function (): void {
+    $this->user = createTestUser();
+    $this->actingAs($this->user);
+});
+
+describe('Cell Attributes', function (): void {
+    it('forwards cell attributes to rendered table cells', function (): void {
+        createTestPost(['user_id' => $this->user->getKey()]);
+
+        $component = Livewire::test(CellAttributesPostDataTable::class);
+        $component->call('loadData');
+
+        $html = $component->html();
+
+        expect($html)->toContain('whitespace-normal');
+        expect($html)->not->toMatch('/class="[^"]*whitespace-nowrap[^"]*whitespace-normal/');
+    });
+
+    it('applies truncation defaults when no cell attributes override whitespace', function (): void {
+        createTestPost(['user_id' => $this->user->getKey()]);
+
+        $component = Livewire::test(PostDataTable::class);
+        $component->call('loadData');
+
+        $html = $component->html();
+
+        expect($html)->toContain('whitespace-nowrap');
+    });
+
+    it('preserves HtmlString values and renders them with line breaks', function (): void {
+        createTestPost([
+            'user_id' => $this->user->getKey(),
+            'content' => "Line one\nLine two",
+        ]);
+
+        $component = Livewire::test(CellAttributesPostDataTable::class);
+        $component->call('loadData');
+
+        $component->assertSeeHtml('Line one<br />');
+    });
+});

--- a/tests/Fixtures/Livewire/CellAttributesPostDataTable.php
+++ b/tests/Fixtures/Livewire/CellAttributesPostDataTable.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Fixtures\Livewire;
+
+use Illuminate\Support\HtmlString;
+use Illuminate\View\ComponentAttributeBag;
+use TeamNiftyGmbH\DataTable\DataTable;
+use TeamNiftyGmbH\DataTable\Htmlables\DataTableRowAttributes;
+use Tests\Fixtures\Models\Post;
+
+class CellAttributesPostDataTable extends DataTable
+{
+    public array $enabledCols = [
+        'title',
+        'content',
+    ];
+
+    protected string $model = Post::class;
+
+    protected function getCellAttributes(): ComponentAttributeBag
+    {
+        return DataTableRowAttributes::make()
+            ->bind('class', '\'whitespace-normal\'');
+    }
+
+    protected function itemToArray($item): array
+    {
+        $item = parent::itemToArray($item);
+
+        $raw = is_array($item['content']) ? $item['content']['raw'] : $item['content'];
+        $item['content'] = new HtmlString(nl2br(e((string) $raw)));
+
+        return $item;
+    }
+}


### PR DESCRIPTION
## Summary
- Forward `cellAttributes` from `getCellAttributes()` to `<x-tall-datatables::table.cell>` in `table-row.blade.php` — they were received as a prop but never applied
- When cellAttributes include a whitespace override, skip the default truncation classes (`whitespace-nowrap max-w-xs overflow-hidden text-ellipsis`) in `cell.blade.php`
- Detect `HtmlString` values in the formatter pipeline and preserve their HTML content instead of stripping tags via `StringFormatter`