### PR TITLE
Drop maatwebsite/excel in favor of phpspreadsheet directly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.4",
         "laravel/framework": "^12.0|^13.0",
         "livewire/livewire": "^4.0",
-        "maatwebsite/excel": "^3.1",
+        "phpoffice/phpspreadsheet": "^5.3",
         "spatie/laravel-model-info": "^1.0|^2.0",
         "tallstackui/tallstackui": "^3.0"
     },

--- a/src/Exports/DataTableExport.php
+++ b/src/Exports/DataTableExport.php
@@ -5,24 +5,41 @@ namespace TeamNiftyGmbH\DataTable\Exports;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder;
-use Maatwebsite\Excel\Concerns\Exportable;
-use Maatwebsite\Excel\Concerns\FromQuery;
-use Maatwebsite\Excel\Concerns\ShouldAutoSize;
-use Maatwebsite\Excel\Concerns\WithHeadings;
-use Maatwebsite\Excel\Concerns\WithMapping;
+use Illuminate\Support\Facades\Storage;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use TeamNiftyGmbH\DataTable\Exports\Concerns\ExportsData;
 
-class DataTableExport implements FromQuery, ShouldAutoSize, WithHeadings, WithMapping
+class DataTableExport
 {
-    use Exportable, ExportsData;
+    use ExportsData;
 
-    private EloquentBuilder $builder;
+    private const CHUNK_SIZE = 1000;
 
-    public function __construct(EloquentBuilder $builder, array $exportColumns = [], array $formatters = [])
-    {
-        $this->builder = $builder;
+    private const XLSX_CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
+    public function __construct(
+        private EloquentBuilder $builder,
+        array $exportColumns = [],
+        array $formatters = [],
+    ) {
         $this->exportColumns = $exportColumns;
         $this->exportFormatters = $formatters;
+    }
+
+    public function download(string $filename): StreamedResponse
+    {
+        $response = new StreamedResponse(function (): void {
+            $this->writeXlsxTo('php://output');
+        });
+
+        $response->headers->set('Content-Type', self::XLSX_CONTENT_TYPE);
+        $response->headers->set('Content-Disposition', 'attachment; filename="' . $filename . '"');
+
+        return $response;
     }
 
     public function map($row): array
@@ -33,5 +50,84 @@ class DataTableExport implements FromQuery, ShouldAutoSize, WithHeadings, WithMa
     public function query(): Relation|EloquentBuilder|Builder
     {
         return $this->builder;
+    }
+
+    public function store(string $path, ?string $disk = null): bool
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'tdt-export-');
+
+        if ($tempFile === false) {
+            throw new RuntimeException('Failed to create temporary file for export.');
+        }
+
+        try {
+            $this->writeXlsxTo($tempFile);
+
+            $stream = fopen($tempFile, 'rb');
+
+            try {
+                $storage = $disk ? Storage::disk($disk) : Storage::disk();
+                $result = $storage->put($path, $stream);
+            } finally {
+                if (is_resource($stream)) {
+                    fclose($stream);
+                }
+            }
+
+            return (bool) $result;
+        } finally {
+            if (file_exists($tempFile)) {
+                @unlink($tempFile);
+            }
+        }
+    }
+
+    private function autoSizeColumns(Worksheet $sheet): void
+    {
+        foreach ($sheet->getColumnIterator() as $column) {
+            $sheet->getColumnDimension($column->getColumnIndex())->setAutoSize(true);
+        }
+    }
+
+    private function writeHeadings(Worksheet $sheet): void
+    {
+        $headings = $this->headings();
+
+        if ($headings === []) {
+            return;
+        }
+
+        $sheet->fromArray([$headings], null, 'A1', true);
+    }
+
+    private function writeRows(Worksheet $sheet): void
+    {
+        $rowIndex = 2;
+
+        $this->builder->chunk(self::CHUNK_SIZE, function ($rows) use ($sheet, &$rowIndex): void {
+            foreach ($rows as $row) {
+                $sheet->fromArray([array_values($this->mapRow($row))], null, 'A' . $rowIndex, true);
+                $rowIndex++;
+            }
+        });
+    }
+
+    private function writeXlsxTo(string $target): void
+    {
+        $spreadsheet = new Spreadsheet();
+
+        try {
+            $sheet = $spreadsheet->getActiveSheet();
+
+            $this->writeHeadings($sheet);
+            $this->writeRows($sheet);
+            $this->autoSizeColumns($sheet);
+
+            $writer = new Xlsx($spreadsheet);
+            $writer->save($target);
+        } finally {
+            $spreadsheet->disconnectWorksheets();
+            unset($spreadsheet);
+        }
     }
 }

--- a/tests/Feature/DataTableExportTest.php
+++ b/tests/Feature/DataTableExportTest.php
@@ -184,3 +184,85 @@ describe('DataTableExport integration', function (): void {
             ->and($mapped['user.name'])->toBe('Export User');
     });
 });
+
+describe('DataTableExport download', function (): void {
+    it('returns a StreamedResponse with xlsx content type', function (): void {
+        $export = new DataTableExport(Post::query(), ['title']);
+
+        $response = $export->download('export.xlsx');
+
+        expect($response)->toBeInstanceOf(Symfony\Component\HttpFoundation\StreamedResponse::class)
+            ->and($response->headers->get('Content-Type'))->toBe('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+            ->and($response->headers->get('Content-Disposition'))->toContain('attachment; filename="export.xlsx"');
+    });
+
+    it('streams a valid xlsx file that can be re-read by phpspreadsheet', function (): void {
+        createTestPost([
+            'user_id' => $this->user->getKey(),
+            'title' => 'Roundtrip Title',
+            'content' => 'Roundtrip Content',
+        ]);
+
+        $export = new DataTableExport(Post::query(), ['title', 'content']);
+        $response = $export->download('roundtrip.xlsx');
+
+        ob_start();
+        $response->sendContent();
+        $body = ob_get_clean();
+
+        $tmp = tempnam(sys_get_temp_dir(), 'tdt-test-');
+        file_put_contents($tmp, $body);
+
+        try {
+            $reader = PhpOffice\PhpSpreadsheet\IOFactory::createReaderForFile($tmp);
+            $spreadsheet = $reader->load($tmp);
+            $rows = $spreadsheet->getActiveSheet()->toArray();
+
+            expect($rows[0])->toBe([__('Title'), __('Content')])
+                ->and($rows[1])->toBe(['Roundtrip Title', 'Roundtrip Content']);
+        } finally {
+            @unlink($tmp);
+        }
+    });
+});
+
+describe('DataTableExport store', function (): void {
+    it('writes an xlsx file to the given storage path', function (): void {
+        Illuminate\Support\Facades\Storage::fake('local');
+
+        createTestPost([
+            'user_id' => $this->user->getKey(),
+            'title' => 'Stored Title',
+        ]);
+
+        $export = new DataTableExport(Post::query(), ['title']);
+        $result = $export->store('exports/test.xlsx', 'local');
+
+        expect($result)->toBeTrue();
+        Illuminate\Support\Facades\Storage::disk('local')->assertExists('exports/test.xlsx');
+
+        $contents = Illuminate\Support\Facades\Storage::disk('local')->get('exports/test.xlsx');
+        $tmp = tempnam(sys_get_temp_dir(), 'tdt-test-');
+        file_put_contents($tmp, $contents);
+
+        try {
+            $reader = PhpOffice\PhpSpreadsheet\IOFactory::createReaderForFile($tmp);
+            $rows = $reader->load($tmp)->getActiveSheet()->toArray();
+
+            expect($rows[1])->toBe(['Stored Title']);
+        } finally {
+            @unlink($tmp);
+        }
+    });
+
+    it('uses the default disk when none is passed', function (): void {
+        Illuminate\Support\Facades\Storage::fake();
+
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Default Disk']);
+
+        $export = new DataTableExport(Post::query(), ['title']);
+        $export->store('exports/default.xlsx');
+
+        Illuminate\Support\Facades\Storage::assertExists('exports/default.xlsx');
+    });
+});

--- a/tests/Feature/SupportsExportingTest.php
+++ b/tests/Feature/SupportsExportingTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Livewire\Livewire;
-use Maatwebsite\Excel\ExcelServiceProvider;
 use Tests\Fixtures\Livewire\NonExportablePostDataTable;
 use Tests\Fixtures\Livewire\PostDataTable;
 use Tests\Fixtures\Livewire\PostWithRelationsDataTable;
@@ -92,11 +91,6 @@ describe('SupportsExporting', function (): void {
     });
 
     describe('export', function (): void {
-        beforeEach(function (): void {
-            // Register the Excel service provider for export tests
-            app()->register(ExcelServiceProvider::class);
-        });
-
         it('returns a download response', function (): void {
             createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Export Test']);
 
@@ -105,7 +99,7 @@ describe('SupportsExporting', function (): void {
 
             $response = $component->instance()->export(['title', 'content']);
 
-            expect($response)->toBeInstanceOf(Symfony\Component\HttpFoundation\BinaryFileResponse::class);
+            expect($response)->toBeInstanceOf(Symfony\Component\HttpFoundation\StreamedResponse::class);
         });
 
         it('generates filename with model name and timestamp', function (): void {
@@ -131,7 +125,7 @@ describe('SupportsExporting', function (): void {
             // Passing columns with some falsy values - array_filter removes empties
             $response = $component->instance()->export(['title', '', 'content']);
 
-            expect($response)->toBeInstanceOf(Symfony\Component\HttpFoundation\BinaryFileResponse::class);
+            expect($response)->toBeInstanceOf(Symfony\Component\HttpFoundation\StreamedResponse::class);
         });
 
         it('exports with no data returns valid response', function (): void {
@@ -140,7 +134,7 @@ describe('SupportsExporting', function (): void {
 
             $response = $component->instance()->export(['title', 'content']);
 
-            expect($response)->toBeInstanceOf(Symfony\Component\HttpFoundation\BinaryFileResponse::class);
+            expect($response)->toBeInstanceOf(Symfony\Component\HttpFoundation\StreamedResponse::class);
         });
 
         it('can be called directly on the component instance', function (): void {
@@ -151,7 +145,7 @@ describe('SupportsExporting', function (): void {
 
             $response = $component->instance()->export(['title', 'content']);
 
-            expect($response)->toBeInstanceOf(Symfony\Component\HttpFoundation\BinaryFileResponse::class);
+            expect($response)->toBeInstanceOf(Symfony\Component\HttpFoundation\StreamedResponse::class);
         });
 
         it('returns a CSV response when format is csv', function (): void {


### PR DESCRIPTION
## Summary
- Removes `maatwebsite/excel` dependency that pinned `phpoffice/phpspreadsheet` to `^1.30` (end-of-life).
- Rewrites `DataTableExport` to use `phpoffice/phpspreadsheet ^5.3` directly.
- Public surface preserved (`__construct`, `download`, `headings`, `map`, `query`); adds `store($path, ?$disk)` to replace external `Excel::store($export, $path)` callers.

## Breaking changes for downstream consumers
Callers that used `Excel::store($export, $path)` with this export class must switch to `$export->store($path)`. Affected in our ecosystem: `flux-core` (`ExportDataTableJob`) — separate PR.