### PR TITLE
Resolve $wire correctly in teleported sidebar

### DIFF
--- a/resources/js/components/datatable-options.js
+++ b/resources/js/components/datatable-options.js
@@ -1,5 +1,6 @@
 export default function datatable_options(wire) {
     return {
+        wire,
         searchRelations: null,
         searchColumns: null,
         searchAggregatable: null,

--- a/resources/views/components/options.blade.php
+++ b/resources/views/components/options.blade.php
@@ -1,6 +1,6 @@
 <div
     class="mt-2 px-1"
-    x-data="datatableOptions($wire)"
+    x-data="datatableOptions(window.Livewire.find('{{ $this->getId() }}'))"
     x-init="
         aggregatable = {{ Js::from($this->getAggregatable()) }};
         groupable = {{ Js::from($this->getGroupableCols()) }};
@@ -41,7 +41,7 @@
                 />
                 <x-button
                     :text="__('Save')"
-                    x-on:click="$wire.saveFilter(filterName, permanent, withEnabledCols, isShared).then(() => $tsui.close.modal('save-filter'));"
+                    x-on:click="wire.saveFilter(filterName, permanent, withEnabledCols, isShared).then(() => $tsui.close.modal('save-filter'));"
                 />
             </x-slot>
         </x-modal>

--- a/resources/views/components/options/tabs/columns.blade.php
+++ b/resources/views/components/options/tabs/columns.blade.php
@@ -1,7 +1,7 @@
 <div
     x-data="{
         attributes: [],
-        availableCols: [...$wire.enabledCols, ...['__placeholder__']],
+        availableCols: [...wire.enabledCols, ...['__placeholder__']],
         addCol(colName) {
             if (this.availableCols.includes(colName))
                 this.availableCols.splice(this.availableCols.indexOf(colName), 1)
@@ -84,7 +84,7 @@
                             searchRelations = null;
                             searchColumns = null;
                             (async () => {
-                                const d = await $wire.loadSlug();
+                                const d = await wire.loadSlug();
                                 selectedCols = d?.cols || [];
                                 selectedRelations = d?.relations || [];
                                 displayPath = d?.displayPath || [];
@@ -103,7 +103,7 @@
                                 searchRelations = null;
                                 searchColumns = null;
                                 (async () => {
-                                    const d = await $wire.loadSlug(segment.value);
+                                    const d = await wire.loadSlug(segment.value);
                                     selectedCols = d?.cols || [];
                                     selectedRelations = d?.relations || [];
                                     displayPath = d?.displayPath || [];
@@ -134,7 +134,7 @@
                     <label class="flex min-w-0 cursor-pointer items-center gap-1.5 overflow-hidden py-1">
                         <x-checkbox
                             sm
-                            x-bind:checked="$wire.enabledCols.includes(col.attribute)"
+                            x-bind:checked="wire.enabledCols.includes(col.attribute)"
                             wire:loading.attr="disabled"
                             x-bind:id="col.attribute"
                             x-bind:value="col.attribute"
@@ -167,7 +167,7 @@
                             searchRelations = null;
                             searchColumns = null;
                             (async () => {
-                                const data = await $wire.loadRelation(relation.model, relation.name);
+                                const data = await wire.loadRelation(relation.model, relation.name);
                                 selectedCols = data?.cols || [];
                                 selectedRelations = data?.relations || [];
                                 displayPath = data?.displayPath || [];
@@ -178,7 +178,7 @@
                             <x-checkbox
                                 sm
                                 x-bind:value="relation.name + '_count'"
-                                x-bind:checked="$wire.enabledCols.includes(relation.name + '_count')"
+                                x-bind:checked="wire.enabledCols.includes(relation.name + '_count')"
                                 x-on:change="addCol(relation.name + '_count'); loadFilterable();"
                                 x-model="enabledCols"
                                 wire:loading.attr="disabled"

--- a/resources/views/components/options/tabs/export.blade.php
+++ b/resources/views/components/options/tabs/export.blade.php
@@ -24,7 +24,7 @@
     />
     <x-button
         loading
-        x-on:click="$wire.export(exportColumns, exportFormat, exportFormatted); $tsui.close.slide('data-table-sidebar-' + $wire.id.toLowerCase());"
+        x-on:click="wire.export(exportColumns, exportFormat, exportFormatted); $tsui.close.slide('data-table-sidebar-{{ strtolower($this->getId()) }}');"
         color="indigo"
         class="w-full"
         :text="__('Export')"

--- a/resources/views/components/options/tabs/filters.blade.php
+++ b/resources/views/components/options/tabs/filters.blade.php
@@ -1,6 +1,6 @@
 <div
     x-cloak
-    x-show="filterIndex > 0 && filterIndex >= ($wire.userFilters || []).length"
+    x-show="filterIndex > 0 && filterIndex >= (wire.userFilters || []).length"
     class="mb-2 rounded-md border border-emerald-200 bg-emerald-50/50 px-3 py-2 text-xs text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-400"
 >
     {{ __('Adding to new OR group') }}
@@ -11,7 +11,7 @@
 >
     @if (auth()->user() && method_exists(auth()->user(), 'datatableUserSettings'))
         <template
-            x-if="$wire.savedFilters?.length > 0"
+            x-if="wire.savedFilters?.length > 0"
         >
             <div>
                 <div
@@ -38,7 +38,7 @@
                         x-data="{ detail: null }"
                     >
                         <template
-                            x-for="(filter, index) in $wire.savedFilters"
+                            x-for="(filter, index) in wire.savedFilters"
                         >
                             <div>
                                 <x-card>
@@ -47,7 +47,7 @@
                                             <div class="flex gap-2 w-full">
                                                 <x-input sm
                                                     x-model="filter.name"
-                                                    x-on:input.debounce="$wire.updateSavedFilter(filter.id, filter)"
+                                                    x-on:input.debounce="wire.updateSavedFilter(filter.id, filter)"
                                                 />
                                                 <x-button.circle
                                                     color="red"
@@ -55,7 +55,7 @@
                                                     icon="x-mark"
                                                     x-on:click="
                                                         savedFilters.splice(index, 1);
-                                                        $wire.deleteSavedFilter(filter.id)
+                                                        wire.deleteSavedFilter(filter.id)
                                                     "
                                                 />
                                             </div>
@@ -103,7 +103,7 @@
                                             <x-button
                                                 :text="__('Apply')"
                                                 color="indigo"
-                                                x-on:click="$wire.loadFilter(filter.settings), detail = null, showSavedFilters = false"
+                                                x-on:click="wire.loadFilter(filter.settings), detail = null, showSavedFilters = false"
                                             />
                                             <x-icon
                                                 name="chevron-left"
@@ -504,8 +504,8 @@
     </div>
     <div class="py-1">
         <x-checkbox
-            x-model="$wire.withSoftDeletes"
-            x-on:change="$wire.startSearch()"
+            x-model="wire.withSoftDeletes"
+            x-on:change="wire.startSearch()"
             :label="__('Include deleted')"
         />
     </div>
@@ -523,10 +523,10 @@
 <div
     class="border-t border-gray-100 pt-3 dark:border-secondary-700/50"
     x-cloak
-    x-show="($wire.userFilters || []).length > 0 || orderByCol || groupBy"
+    x-show="(wire.userFilters || []).length > 0 || orderByCol || groupBy"
 >
 <div class="flex flex-col gap-1.5">
-    <template x-for="(orFilters, orIndex) in ($wire.userFilters || [])">
+    <template x-for="(orFilters, orIndex) in (wire.userFilters || [])">
         <div>
             <div
                 class="group/fg flex flex-wrap items-center gap-1.5 rounded px-2 py-1.5 transition-colors"
@@ -573,7 +573,7 @@
                     <x-icon name="x-mark" class="h-5 w-5" />
                 </button>
             </div>
-            <template x-if="($wire.userFilters || []).length - 1 !== orIndex">
+            <template x-if="(wire.userFilters || []).length - 1 !== orIndex">
                 <div class="flex justify-center py-1">
                     <x-badge
                         flat
@@ -603,7 +603,7 @@
                     2xs
                     flat
                     icon="x-mark"
-                    x-on:click="$wire.sortTable('')"
+                    x-on:click="wire.sortTable('')"
                 />
             </x-slot>
         </x-badge>
@@ -623,7 +623,7 @@
                     2xs
                     flat
                     icon="x-mark"
-                    x-on:click="groupBy = null; $wire.setGroupBy(null)"
+                    x-on:click="groupBy = null; wire.setGroupBy(null)"
                 />
             </x-slot>
         </x-badge>
@@ -631,7 +631,7 @@
     <button
         type="button"
         x-cloak
-        x-show="($wire.userFilters || []).length > 0"
+        x-show="(wire.userFilters || []).length > 0"
         x-on:click="addOrFilter()"
         class="cursor-pointer text-sm text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300"
     >

--- a/resources/views/components/options/tabs/grouping.blade.php
+++ b/resources/views/components/options/tabs/grouping.blade.php
@@ -2,8 +2,8 @@
     <span class="mb-2 block text-xs font-medium tracking-wide text-gray-500 dark:text-gray-400">{{ __('Rows per group') }}</span>
     <x-select.native
         sm
-        x-model="$wire.groupPerPage"
-        x-on:change="$wire.loadData()"
+        x-model="wire.groupPerPage"
+        x-on:change="wire.loadData()"
     >
         <option value="5">5</option>
         <option value="10">10</option>
@@ -30,7 +30,7 @@
             :label="__('No grouping')"
             value=""
             x-bind:checked="! groupBy"
-            x-on:change="groupBy = null; $wire.setGroupBy(null)"
+            x-on:change="groupBy = null; wire.setGroupBy(null)"
         />
         <x-icon
             name="view-columns"
@@ -43,7 +43,7 @@
             name="groupBy"
             x-bind:value="col"
             x-bind:checked="groupBy === col"
-            x-on:change="groupBy = col; $wire.setGroupBy(col)"
+            x-on:change="groupBy = col; wire.setGroupBy(col)"
         >
             <x-slot:label>
                 <span x-text="getLabel(col)"></span>

--- a/resources/views/livewire/data-table.blade.php
+++ b/resources/views/livewire/data-table.blade.php
@@ -12,7 +12,7 @@
                         color="secondary"
                         light
                         :text="__('Close')"
-                        x-on:click="$tsui.close.slide('data-table-sidebar-' + $wire.id.toLowerCase());"
+                        x-on:click="$tsui.close.slide('data-table-sidebar-{{ strtolower($this->getId()) }}');"
                     />
                 </x-slot>
             </x-slide>


### PR DESCRIPTION
## Summary

The DataTable sidebar (`<x-tall-datatables::options />`) is rendered inside `@teleport('body')`, which moves the block to body level at server-render time and severs its `wire:id` ancestor chain. Alpine's `$wire` magic walks the DOM upward, so inside the teleported markup `$wire` either resolved to an unrelated Livewire component on the page or was undefined entirely.

Symptoms in the browser console:

- `TypeError: $wire.enabledCols is not iterable` (columns tab)
- `TypeError: t.split is not a function` from `getLabel(orderByCol)` / `getLabel(groupBy)` (filters tab)
- `availableCols is not defined` (cascade from the failed `x-data` block)
- `Cannot read properties of undefined (reading 'selectedCols')` in `loadSidebarData`
- Save-filter, export and slide-close handlers silently no-oped

## Fix

- Target the DataTable explicitly via `window.Livewire.find('{{ $this->getId() }}')` in the options Alpine root.
- Expose the resolved component as `wire` on the Alpine data scope (in `datatable_options(wire)`).
- Replace every `$wire.*` reference inside the teleported tab views (`columns`, `filters`, `grouping`, `export`) with the scope-bound `wire.*` alias.
- Hard-code the slide id in close handlers (`data-table.blade.php`, `export.blade.php`) since the id is known server-side as `strtolower($this->getId())`.

Verified locally: opening the sidebar, switching tabs, and triggering the previously-broken expressions now produce zero console errors.