### PR TITLE
Keep modelKeyName scalar when Scout highlights the key column

### DIFF
--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -436,6 +436,12 @@ trait BuildsQueries
 
                     // Apply Scout highlights without destroying formatters
                     foreach ($this->enabledCols as $key) {
+                        // Never wrap the modelKeyName — it's used as scalar (wire:key,
+                        // x-sort:item, JS identifiers) and array values break rendering.
+                        if ($key === $this->modelKeyName) {
+                            continue;
+                        }
+
                         $highlighted = data_get($query->hits, $item->getKey() . '._formatted.' . $key);
                         if ($highlighted === null) {
                             continue;

--- a/tests/Feature/BuildsQueriesTest.php
+++ b/tests/Feature/BuildsQueriesTest.php
@@ -2361,6 +2361,39 @@ describe('buildSearch with Scout Searchable model', function (): void {
 
         expect($result)->toBeTrue();
     });
+
+    it('keeps modelKeyName scalar when Scout highlights the key column', function (): void {
+        config(['scout.driver' => 'collection']);
+
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Scout Highlight Post']);
+
+        $component = Livewire::test(Tests\Fixtures\Livewire\IdEnabledSearchableDataTable::class);
+        $component->set('search', 'Scout');
+        $component->call('loadData');
+
+        $data = $component->instance()->getDataForTesting();
+
+        expect($data['data'])->not->toBeEmpty();
+        expect($data['data'][0]['id'])->toBeScalar();
+    });
+
+    it('still applies Scout highlights to non-key columns', function (): void {
+        config(['scout.driver' => 'collection']);
+
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Scout Match Post']);
+
+        $component = Livewire::test(Tests\Fixtures\Livewire\IdEnabledSearchableDataTable::class);
+        $component->set('search', 'Scout');
+        $component->call('loadData');
+
+        $data = $component->instance()->getDataForTesting();
+
+        expect($data['data'][0]['title'])
+            ->toBeArray()
+            ->toHaveKey('display')
+            ->toHaveKey('raw');
+        expect($data['data'][0]['title']['display'])->toContain('<mark>');
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/Fixtures/Livewire/IdEnabledSearchableDataTable.php
+++ b/tests/Fixtures/Livewire/IdEnabledSearchableDataTable.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Fixtures\Livewire;
+
+use Illuminate\Database\Eloquent\Builder;
+use TeamNiftyGmbH\DataTable\DataTable;
+use Tests\Fixtures\Models\SearchablePost;
+
+class IdEnabledSearchableDataTable extends DataTable
+{
+    public array $enabledCols = [
+        'id',
+        'title',
+        'content',
+    ];
+
+    protected string $model = SearchablePost::class;
+
+    /**
+     * Override to simulate a Scout search result with hits/scout_pagination.
+     * Avoids needing a live Meilisearch instance for tests.
+     */
+    protected function buildSearch(bool $unpaginated = false): Builder
+    {
+        $query = SearchablePost::query();
+
+        if ($this->search && ! $unpaginated) {
+            $hits = SearchablePost::query()
+                ->where('title', 'like', '%' . $this->search . '%')
+                ->get()
+                ->mapWithKeys(function (SearchablePost $post): array {
+                    return [
+                        $post->getKey() => [
+                            'id' => $post->getKey(),
+                            'title' => $post->title,
+                            'content' => $post->content,
+                            '_formatted' => [
+                                'id' => (string) $post->getKey(),
+                                'title' => str_ireplace($this->search, '<mark>' . $this->search . '</mark>', (string) $post->title),
+                                'content' => (string) $post->content,
+                            ],
+                        ],
+                    ];
+                })
+                ->all();
+
+            $query->whereKey(array_keys($hits));
+            $query->hits = $hits;
+            $query->scout_pagination = [
+                'estimatedTotalHits' => count($hits),
+                'limit' => $this->perPage,
+                'offset' => 0,
+            ];
+        }
+
+        return $query;
+    }
+}


### PR DESCRIPTION
## Summary

When a model with the Searchable trait runs a Scout search and the `modelKeyName` is part of `enabledCols`, the highlight loop in `BuildsQueries::getResultFromQuery()` wrapped the row key value as `['raw' => x, 'display' => y]`. Downstream consumers (`wire:key`, `x-sort:item`, JS identifiers) treat this value as scalar, so rendering crashed with `htmlspecialchars(): Argument #1 ($string) must be of type string, array given`.

Skip wrapping the `modelKeyName` so the row key stays scalar, while still allowing Scout highlights on every other enabled column.