### PR TITLE
Add onChunk callback to DataTableExport

### DIFF
--- a/src/Exports/DataTableExport.php
+++ b/src/Exports/DataTableExport.php
@@ -2,6 +2,7 @@
 
 namespace TeamNiftyGmbH\DataTable\Exports;
 
+use Closure;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder;
@@ -17,7 +18,7 @@ class DataTableExport
 {
     use ExportsData;
 
-    private const CHUNK_SIZE = 1000;
+    private const CHUNK_SIZE = 250;
 
     private const XLSX_CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
 
@@ -25,6 +26,7 @@ class DataTableExport
         private EloquentBuilder $builder,
         array $exportColumns = [],
         array $formatters = [],
+        private ?Closure $onChunk = null,
     ) {
         $this->exportColumns = $exportColumns;
         $this->exportFormatters = $formatters;
@@ -103,11 +105,17 @@ class DataTableExport
     private function writeRows(Worksheet $sheet): void
     {
         $rowIndex = 2;
+        $processed = 0;
 
-        $this->builder->chunk(self::CHUNK_SIZE, function ($rows) use ($sheet, &$rowIndex): void {
+        $this->builder->chunk(self::CHUNK_SIZE, function ($rows) use ($sheet, &$rowIndex, &$processed): void {
             foreach ($rows as $row) {
                 $sheet->fromArray([array_values($this->mapRow($row))], null, 'A' . $rowIndex, true);
                 $rowIndex++;
+                $processed++;
+            }
+
+            if (! is_null($this->onChunk)) {
+                ($this->onChunk)($processed);
             }
         });
     }


### PR DESCRIPTION
## Summary

- Adds an optional `?Closure $onChunk` constructor argument to `DataTableExport`. When provided, the closure is invoked after every chunk is written with the cumulative processed-row count, enabling consumers to stream export progress without coupling the export to a specific notification channel.
- Lowers `CHUNK_SIZE` from 1000 to 250 so progress updates on medium-sized exports feel less stepwise.

Used by flux-core's `ExportDataTableJob` to drive its queue-monitor progress toast.