### PR TITLE
Replace removed Livewire $focusOn magic with $tsui.focus

### DIFF
--- a/resources/views/components/options.blade.php
+++ b/resources/views/components/options.blade.php
@@ -13,7 +13,7 @@
             id="save-filter"
             :title="__('Save filter')"
             x-on:close="filterName = ''; permanent = false; isShared = false;"
-            x-on:open="$focusOn('filter-name')"
+            x-on:open="$tsui.focus('filter-name')"
         >
             <x-input sm
                 required


### PR DESCRIPTION
## Summary
- The save-filter modal triggered `ReferenceError: $focusOn is not defined` on every open because Livewire 4 removed the `$focusOn` magic helper.
- Switch to TallStackUI's `$tsui.focus(name)` magic, which resolves the target by `data-focus`, `id`, or `x-ref` and matches the previous behavior.