### PR TITLE
Normalize enabledCols to a sequential list at every assignment

### DIFF
--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -634,6 +634,10 @@ class DataTable extends Component
             $this->userMultiSort = [];
         }
 
+        if (array_key_exists('enabledCols', $properties) && is_array($properties['enabledCols'])) {
+            $properties['enabledCols'] = array_values($properties['enabledCols']);
+        }
+
         foreach ($properties as $property => $value) {
             $this->{$property} = $value;
         }

--- a/src/Traits/DataTables/StoresSettings.php
+++ b/src/Traits/DataTables/StoresSettings.php
@@ -147,7 +147,9 @@ trait StoresSettings
             ->first();
 
         if ($defaultColumns) {
-            $this->enabledCols = data_get($defaultColumns->settings, 'enabledCols', $this->enabledCols);
+            $this->enabledCols = array_values(
+                data_get($defaultColumns->settings, 'enabledCols', $this->enabledCols)
+            );
         }
 
         $this->savedFilters = $this->getSavedFilters(
@@ -210,7 +212,9 @@ trait StoresSettings
                 ->first();
 
             if ($defaultColumns) {
-                $this->enabledCols = data_get($defaultColumns->settings, 'enabledCols', $this->enabledCols);
+                $this->enabledCols = array_values(
+                    data_get($defaultColumns->settings, 'enabledCols', $this->enabledCols)
+                );
             }
 
             $this->colLabels = $this->getColLabels();
@@ -290,7 +294,7 @@ trait StoresSettings
     #[Renderless]
     public function storeColLayout(array $cols): void
     {
-        $this->enabledCols = $cols;
+        $this->enabledCols = array_values($cols);
         $this->colLabels = $this->getColLabels();
 
         $this->cacheState();

--- a/tests/Feature/StoresSettingsTest.php
+++ b/tests/Feature/StoresSettingsTest.php
@@ -355,6 +355,23 @@ describe('loadSavedFilter', function (): void {
         expect($freshComponent->get('enabledCols'))->toBe(['title', 'content']);
     });
 
+    it('normalizes enabledCols loaded from a layout filter with non-sequential keys', function (): void {
+        $this->user->datatableUserSettings()->create([
+            'name' => 'layout',
+            'component' => PostDataTable::class,
+            'cache_key' => PostDataTable::class,
+            'settings' => ['enabledCols' => [0 => 'title', 2 => 'content', 4 => 'author_id']],
+            'is_layout' => true,
+        ]);
+
+        $component = Livewire::test(PostDataTable::class);
+
+        $enabledCols = $component->get('enabledCols');
+
+        expect(array_is_list($enabledCols))->toBeTrue()
+            ->and($enabledCols)->toBe(['title', 'content', 'author_id']);
+    });
+
     it('applies perPage from saved filter', function (): void {
         Livewire::test(PostDataTable::class)
             ->set('perPage', 50)


### PR DESCRIPTION
## Summary

- Saved layout/filter settings can land in \`enabledCols\` with non-sequential numeric keys after columns are toggled off; PHP then serializes the property as a JSON object, the client receives a non-array, and \`wire.enabledCols.includes()\` in the column options template throws on every render.
- Apply \`array_values()\` at every spot where \`enabledCols\` is hydrated from external state (default columns lookup, \`resetLayout\` restore, \`storeColLayout\`, \`loadFilter\`) so the property is always a list end-to-end.