### PR TITLE
fix: normalize enabledCols to sequential list on every assignment

### DIFF
--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -634,6 +634,10 @@ class DataTable extends Component
             $this->userMultiSort = [];
         }
 
+        if (array_key_exists('enabledCols', $properties) && is_array($properties['enabledCols'])) {
+            $properties['enabledCols'] = array_values($properties['enabledCols']);
+        }
+
         foreach ($properties as $property => $value) {
             $this->{$property} = $value;
         }

--- a/src/Traits/DataTables/StoresSettings.php
+++ b/src/Traits/DataTables/StoresSettings.php
@@ -147,7 +147,9 @@ trait StoresSettings
             ->first();
 
         if ($defaultColumns) {
-            $this->enabledCols = data_get($defaultColumns->settings, 'enabledCols', $this->enabledCols);
+            $this->enabledCols = array_values(
+                data_get($defaultColumns->settings, 'enabledCols', $this->enabledCols)
+            );
         }
 
         $this->savedFilters = $this->getSavedFilters(
@@ -210,7 +212,9 @@ trait StoresSettings
                 ->first();
 
             if ($defaultColumns) {
-                $this->enabledCols = data_get($defaultColumns->settings, 'enabledCols', $this->enabledCols);
+                $this->enabledCols = array_values(
+                    data_get($defaultColumns->settings, 'enabledCols', $this->enabledCols)
+                );
             }
 
             $this->colLabels = $this->getColLabels();
@@ -290,7 +294,7 @@ trait StoresSettings
     #[Renderless]
     public function storeColLayout(array $cols): void
     {
-        $this->enabledCols = $cols;
+        $this->enabledCols = array_values($cols);
         $this->colLabels = $this->getColLabels();
 
         $this->cacheState();

--- a/tests/Feature/StoresSettingsTest.php
+++ b/tests/Feature/StoresSettingsTest.php
@@ -355,6 +355,23 @@ describe('loadSavedFilter', function (): void {
         expect($freshComponent->get('enabledCols'))->toBe(['title', 'content']);
     });
 
+    it('normalizes enabledCols loaded from a layout filter with non-sequential keys', function (): void {
+        $this->user->datatableUserSettings()->create([
+            'name' => 'layout',
+            'component' => PostDataTable::class,
+            'cache_key' => PostDataTable::class,
+            'settings' => ['enabledCols' => [0 => 'title', 2 => 'content', 4 => 'author_id']],
+            'is_layout' => true,
+        ]);
+
+        $component = Livewire::test(PostDataTable::class);
+
+        $enabledCols = $component->get('enabledCols');
+
+        expect(array_is_list($enabledCols))->toBeTrue()
+            ->and($enabledCols)->toBe(['title', 'content', 'author_id']);
+    });
+
     it('applies perPage from saved filter', function (): void {
         Livewire::test(PostDataTable::class)
             ->set('perPage', 50)


### PR DESCRIPTION
## Summary
- \`array_diff\` preserves keys when removing entries, leaving \`enabledCols\` as a sparse PHP array (e.g. \`{0,1,2,3,5,6,7}\`).
- Livewire's snapshot then encodes the sparse array as a JSON object, so Alpine's \`wire.enabledCols.includes\` and the spread \`[...wire.enabledCols]\` both throw \`enabledCols is not iterable / not a function\` on the client.
- Wrapping every assignment in \`array_values()\` re-indexes the array and keeps the snapshot a proper JSON list.