### PR TITLE
fix(SupportsRelations): re-index enabledCols after removing missing relations

### DIFF
--- a/src/Traits/DataTables/SupportsRelations.php
+++ b/src/Traits/DataTables/SupportsRelations.php
@@ -333,7 +333,7 @@ trait SupportsRelations
                     $filterable[] = $enabledCol;
                     $sortable[] = $enabledCol;
                 } catch (BadMethodCallException) {
-                    $this->enabledCols = array_diff($this->enabledCols, [$enabledCol]);
+                    $this->enabledCols = array_values(array_diff($this->enabledCols, [$enabledCol]));
                 }
 
                 continue;
@@ -357,7 +357,7 @@ trait SupportsRelations
                         $relationInstance = $modelBase->{$relationName}();
                     }
                 } catch (BadMethodCallException) {
-                    $this->enabledCols = array_diff($this->enabledCols, [$enabledCol]);
+                    $this->enabledCols = array_values(array_diff($this->enabledCols, [$enabledCol]));
 
                     continue 2;
                 }


### PR DESCRIPTION
## Summary
- `constructWith()` calls `array_diff($this->enabledCols, [$enabledCol])` in two places when a relation segment cannot be resolved (`BadMethodCallException`). Keys are preserved → sparse array → Livewire snapshot turns it into a JSON object → Alpine's `wire.enabledCols.includes()` throws `is not a function` on every list whose default `enabledCols` references a relation that the current dataset doesn't expose.
- Wraps both assignments in `array_values(...)` to keep the list sequential.
- The previous normalization (#242) only patched the `StoresSettings` boundary. #243 squash-merged as an empty commit because GitHub matched the title against #242, so the SupportsRelations branch was never actually applied — observed by visiting /abrechnung against v2.4.18 vendor and seeing 35 `wire.enabledCols.includes is not a function` errors that disappear with this patch.