### PR TITLE
fix(StoresSettings): resetLayout query + deleteSavedFilter button

### DIFF
--- a/resources/views/components/options/tabs/filters.blade.php
+++ b/resources/views/components/options/tabs/filters.blade.php
@@ -53,10 +53,7 @@
                                                     color="red"
                                                     2xs
                                                     icon="x-mark"
-                                                    x-on:click="
-                                                        savedFilters.splice(index, 1);
-                                                        wire.deleteSavedFilter(filter.id)
-                                                    "
+                                                    x-on:click="wire.deleteSavedFilter(filter.id)"
                                                 />
                                             </div>
                                         </template>

--- a/src/Traits/DataTables/StoresSettings.php
+++ b/src/Traits/DataTables/StoresSettings.php
@@ -189,7 +189,8 @@ trait StoresSettings
             $this->ensureAuthHasTrait();
             $layout = Auth::user()
                 ->datatableUserSettings()
-                ->where('component', $this->getCacheKey())
+                ->where('component', static::class)
+                ->where('cache_key', $this->getCacheKey())
                 ->where('is_layout', true)
                 ->first();
             $cached = Session::get(config('tall-datatables.cache_key') . '.filter:' . $this->getCacheKey());

--- a/tests/Feature/StoresSettingsTest.php
+++ b/tests/Feature/StoresSettingsTest.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Session;
 use Livewire\Livewire;
 use TeamNiftyGmbH\DataTable\Exceptions\MissingTraitException;
 use TeamNiftyGmbH\DataTable\Models\DatatableUserSetting;
+use Tests\Fixtures\Livewire\CustomCacheKeyPostDataTable;
 use Tests\Fixtures\Livewire\PostDataTable;
 
 beforeEach(function (): void {
@@ -757,6 +758,26 @@ describe('resetLayout', function (): void {
 
         expect($component->get('perPage'))->toBe(15);
         expect($component->get('search'))->toBe('');
+    });
+
+    it('deletes layout filter from database when cacheKey differs from component class', function (): void {
+        $this->user->datatableUserSettings()->create([
+            'name' => 'layout',
+            'component' => CustomCacheKeyPostDataTable::class,
+            'cache_key' => 'custom-cache-key',
+            'settings' => ['perPage' => 40, 'enabledCols' => ['title']],
+            'is_layout' => true,
+        ]);
+
+        expect(DatatableUserSetting::where('is_layout', true)->exists())->toBeTrue();
+
+        $component = Livewire::test(CustomCacheKeyPostDataTable::class);
+
+        expect($component->instance()->getCacheKey())->toBe('custom-cache-key');
+
+        $component->call('resetLayout');
+
+        expect(DatatableUserSetting::where('is_layout', true)->exists())->toBeFalse();
     });
 });
 

--- a/tests/Fixtures/Livewire/CustomCacheKeyPostDataTable.php
+++ b/tests/Fixtures/Livewire/CustomCacheKeyPostDataTable.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Fixtures\Livewire;
+
+use Livewire\Attributes\Layout;
+use Livewire\Attributes\Locked;
+use TeamNiftyGmbH\DataTable\DataTable;
+use Tests\Fixtures\Models\Post;
+
+#[Layout('components.layouts.app')]
+class CustomCacheKeyPostDataTable extends DataTable
+{
+    #[Locked]
+    public ?string $cacheKey = 'custom-cache-key';
+
+    public array $enabledCols = [
+        'title',
+        'content',
+        'price',
+        'is_published',
+        'created_at',
+    ];
+
+    protected string $model = Post::class;
+}


### PR DESCRIPTION
## Summary

Two unrelated regressions in the saved-settings UI for tall-datatables, surfaced by user reports on the recruiting list:

1. **`resetLayout` did not delete the user layout for components with a custom `cacheKey`.** The query scoped by `component = $this->getCacheKey()`, but the `component` column stores `static::class` and the cache key lives in `cache_key`. Matched accidentally when `cacheKey` defaults to the class name; missed for `OrderList`, `OrderPositions`, `ProductList`, etc. — leaving the user layout in the DB so the next mount overrode the global default again. Query now joins on `component = static::class AND cache_key = $this->getCacheKey()`, matching the writes in `cacheState` / `compileStoredLayout`.

2. **The red x button on saved filters did nothing.** The Alpine handler ran `savedFilters.splice(index, 1); wire.deleteSavedFilter(filter.id)`, but `savedFilters` is only a Livewire property exposed via `wire.savedFilters` — the bare identifier threw a `ReferenceError` before the delete call. The optimistic splice was redundant anyway; `deleteSavedFilter` reassigns `$this->savedFilters` on the server and the `x-for` re-renders. Dropped the local splice.

## Coverage

- New TDD test `resetLayout → it deletes layout filter from database when cacheKey differs from component class` reproduces the bug via a fixture component that sets a non-class `cacheKey`. Failed against the old query, passes after the fix.
- All 106 existing `StoresSettings` / `DefaultColumns` / `Resizable` tests still pass.
- Blade fix is view-only; no PHP test added since `deleteSavedFilter` itself is already covered by existing tests.