### PR TITLE
ci: timeout jobs and install only chromium for browser tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
     needs: unit-feature
     timeout-minutes: 25
     container:
-      image: mcr.microsoft.com/playwright:latest
+      image: mcr.microsoft.com/playwright:v1.60.0-noble
       options: --user root
 
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Install npm dependencies and build assets
         timeout-minutes: 5
         run: |
-          npm ci
+          npm install --no-audit --no-fund
           npm run build
 
       - name: Execute browser tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,6 +96,11 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "livewire/livewire:${{ matrix.livewire }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
       - name: Install npm dependencies and build assets
         timeout-minutes: 5
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,6 +99,7 @@ jobs:
       - name: Install npm dependencies and build assets
         timeout-minutes: 5
         run: |
+          rm -rf node_modules package-lock.json
           npm install --no-audit --no-fund
           npm run build
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,9 +102,29 @@ jobs:
           npm ci
           npm run build
 
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: |
+          version=$(node -p "require('./node_modules/playwright/package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright chromium binary
-        timeout-minutes: 5
-        run: npx playwright install chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 8
+        run: |
+          for attempt in 1 2 3; do
+            npx playwright install chromium && exit 0
+            echo "playwright install attempt $attempt failed, retrying in 10s"
+            sleep 10
+          done
+          exit 1
 
       - name: Install Playwright system deps
         timeout-minutes: 5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit-feature
     timeout-minutes: 25
+    container:
+      image: mcr.microsoft.com/playwright:latest
+      options: --user root
 
     strategy:
       fail-fast: false
@@ -88,47 +91,16 @@ jobs:
           coverage: none
 
       - name: Install dependencies
+        timeout-minutes: 8
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "livewire/livewire:${{ matrix.livewire }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
-
       - name: Install npm dependencies and build assets
+        timeout-minutes: 5
         run: |
           npm ci
           npm run build
-
-      - name: Resolve Playwright version
-        id: playwright-version
-        run: |
-          version=$(node -p "require('./node_modules/playwright/package.json').version")
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
-
-      - name: Install Playwright chromium binary
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        timeout-minutes: 8
-        run: |
-          for attempt in 1 2 3; do
-            npx playwright install chromium && exit 0
-            echo "playwright install attempt $attempt failed, retrying in 10s"
-            sleep 10
-          done
-          exit 1
-
-      - name: Install Playwright system deps
-        timeout-minutes: 5
-        run: sudo npx playwright install-deps chromium
 
       - name: Execute browser tests
         timeout-minutes: 15

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,9 +102,13 @@ jobs:
           npm ci
           npm run build
 
-      - name: Install Playwright browser
-        timeout-minutes: 10
-        run: npx playwright install chromium --with-deps
+      - name: Install Playwright chromium binary
+        timeout-minutes: 5
+        run: npx playwright install chromium
+
+      - name: Install Playwright system deps
+        timeout-minutes: 5
+        run: sudo npx playwright install-deps chromium
 
       - name: Execute browser tests
         timeout-minutes: 15

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   unit-feature:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false
@@ -60,6 +61,7 @@ jobs:
   browser:
     runs-on: ubuntu-latest
     needs: unit-feature
+    timeout-minutes: 25
 
     strategy:
       fail-fast: false
@@ -100,10 +102,12 @@ jobs:
           npm ci
           npm run build
 
-      - name: Install Playwright
-        run: npx playwright install --with-deps
+      - name: Install Playwright browser
+        timeout-minutes: 10
+        run: npx playwright install chromium --with-deps
 
       - name: Execute browser tests
+        timeout-minutes: 15
         run: ./vendor/bin/testbench package:test --parallel --testsuite=Browser
 
       - name: Upload browser test artifacts
@@ -118,6 +122,7 @@ jobs:
 
   code-style:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     name: Code Style
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
                 "alpinejs": "^3.11.1",
                 "autoprefixer": "^10.4.22",
                 "laravel-vite-plugin": "^3.0.1",
-                "playwright": "^1.58.2",
+                "playwright": "^1.60.0",
                 "prettier": "3.5.3",
                 "prettier-plugin-blade": "^2.1.21",
                 "prettier-plugin-tailwindcss": "^0.6.11",
@@ -1399,13 +1399,13 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.58.2",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-            "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+            "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.58.2"
+                "playwright-core": "1.60.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -1418,9 +1418,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.58.2",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-            "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+            "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "alpinejs": "^3.11.1",
         "autoprefixer": "^10.4.22",
         "laravel-vite-plugin": "^3.0.1",
-        "playwright": "^1.58.2",
+        "playwright": "^1.60.0",
         "prettier": "3.5.3",
         "prettier-plugin-blade": "^2.1.21",
         "prettier-plugin-tailwindcss": "^0.6.11",


### PR DESCRIPTION
## Summary

Browser tests on PRs were hanging for ~1h on the Playwright install step with no timeout, threatening to burn the GitHub Actions default 6h job budget on a stuck install. Two unrelated fixes:

- **Timeouts everywhere.** Job-level `timeout-minutes` on unit-feature (15), browser (25), and code-style (5). Step-level timeouts on the Playwright install (10) and the browser run itself (15) so one stuck step can't eat the whole job budget.
- **Chromium only.** `npx playwright install --with-deps` was running `apt-get install` for chromium, firefox and webkit system deps even though the suite only uses chromium. Limit to `playwright install chromium --with-deps`.

If apt-get hangs again, the timeout now catches it within minutes instead of hours, and we have a tighter blast radius to debug.