### PR TITLE
Fix wire:click/x-on:click on Livewire v4 + prompt to reset other user layouts on Set as Default

### DIFF
--- a/resources/views/components/head.blade.php
+++ b/resources/views/components/head.blade.php
@@ -259,7 +259,7 @@
                 rounded
                 color="red"
                 :text="__('Clear')"
-                wire:click="clearFiltersAndSort"
+                wire:click="clearFiltersAndSort()"
                 class="h-8"
             />
         </div>

--- a/resources/views/components/options/tabs/columns.blade.php
+++ b/resources/views/components/options/tabs/columns.blade.php
@@ -63,7 +63,18 @@
                 color="primary"
                 light
                 loading="saveDefaultColumns"
-                wire:click="saveDefaultColumns()"
+                x-on:click="
+                    $tsui.interaction('dialog')
+                        .wireable($wire.__instance.id)
+                        .warning(
+                            '{{ __('Set as Default') }}',
+                            '{{ __('Should personal layouts of other users for this table be reset? Their saved filters remain.') }}',
+                            'amber',
+                        )
+                        .confirm('{{ __('Save default and reset others') }}', () => $wire.saveDefaultColumns(true))
+                        .cancel('{{ __('Save default only') }}', () => $wire.saveDefaultColumns(false))
+                        .send()
+                "
                 :text="__('Set as Default')"
             />
         @endif

--- a/resources/views/components/options/tabs/columns.blade.php
+++ b/resources/views/components/options/tabs/columns.blade.php
@@ -55,7 +55,7 @@
             color="secondary"
             light
             loading="resetLayout"
-            x-on:click="resetLayout"
+            x-on:click="$wire.resetLayout()"
             :text="__('Reset Layout')"
         />
         @if($this->canSaveDefaultColumns())
@@ -63,7 +63,7 @@
                 color="primary"
                 light
                 loading="saveDefaultColumns"
-                wire:click="saveDefaultColumns"
+                wire:click="saveDefaultColumns()"
                 :text="__('Set as Default')"
             />
         @endif

--- a/resources/views/livewire/filters.blade.php
+++ b/resources/views/livewire/filters.blade.php
@@ -11,7 +11,7 @@
                     color="red"
                     flat
                     sm
-                    wire:click="clearFilters"
+                    wire:click="clearFilters()"
                 />
             </div>
 

--- a/src/Traits/DataTables/StoresSettings.php
+++ b/src/Traits/DataTables/StoresSettings.php
@@ -225,7 +225,7 @@ trait StoresSettings
     }
 
     #[Renderless]
-    public function saveDefaultColumns(): void
+    public function saveDefaultColumns(bool $resetOtherUserLayouts = false): void
     {
         if (! $this->canSaveDefaultColumns()) {
             return;
@@ -250,6 +250,14 @@ trait StoresSettings
                 'authenticatable_type' => Auth::user()->getMorphClass(),
             ]
         );
+
+        if ($resetOtherUserLayouts) {
+            $settingModel::query()
+                ->where('component', static::class)
+                ->where('cache_key', $this->getCacheKey())
+                ->where('is_layout', true)
+                ->delete();
+        }
     }
 
     /**

--- a/tests/Browser/FilterInputSyncBrowserTest.php
+++ b/tests/Browser/FilterInputSyncBrowserTest.php
@@ -132,7 +132,7 @@ describe('Filter Input Sync on Badge Removal', function (): void {
 
         // Click the "Clear" button
         $page->script('() => {
-            const buttons = document.querySelectorAll("[wire\\\\:click=\\"clearFiltersAndSort\\"]");
+            const buttons = document.querySelectorAll("[wire\\\\:click=\\"clearFiltersAndSort()\\"]");
             if (buttons.length > 0) buttons[0].click();
         }');
 

--- a/tests/Feature/DefaultColumnsTest.php
+++ b/tests/Feature/DefaultColumnsTest.php
@@ -29,10 +29,11 @@ describe('Global Default Columns', function (): void {
                 ->assertSee(__('Set as Default'));
         });
 
-        it('renders Set as Default button with wire:click parentheses (Livewire v4)', function (): void {
+        it('renders Set as Default button with dialog invoking saveDefaultColumns with bool flag (Livewire v4)', function (): void {
             $html = Livewire::test(DefaultColumnsPostDataTable::class)->html();
 
-            expect($html)->toContain('wire:click="saveDefaultColumns()"')
+            expect($html)->toContain('$wire.saveDefaultColumns(true)')
+                ->and($html)->toContain('$wire.saveDefaultColumns(false)')
                 ->and($html)->not->toContain('wire:click="saveDefaultColumns"');
         });
 
@@ -75,6 +76,114 @@ describe('Global Default Columns', function (): void {
             expect(DatatableUserSetting::where('is_default_columns', true)->count())->toBe(1);
             $setting = DatatableUserSetting::where('is_default_columns', true)->first();
             expect($setting->settings['enabledCols'])->toBe(['id', 'title', 'created_at']);
+        });
+
+        describe('with resetOtherUserLayouts flag', function (): void {
+            it('deletes all is_layout rows for the same component when true', function (): void {
+                DatatableUserSetting::create([
+                    'name' => 'OtherUserLayout',
+                    'component' => DefaultColumnsPostDataTable::class,
+                    'cache_key' => DefaultColumnsPostDataTable::class,
+                    'settings' => ['enabledCols' => ['id']],
+                    'is_layout' => true,
+                    'is_default_columns' => false,
+                    'is_permanent' => false,
+                    'authenticatable_id' => $this->otherUser->getKey(),
+                    'authenticatable_type' => get_class($this->otherUser),
+                ]);
+
+                Livewire::test(DefaultColumnsPostDataTable::class)
+                    ->call('loadData')
+                    ->set('enabledCols', ['id', 'title'])
+                    ->call('saveDefaultColumns', true);
+
+                expect(DatatableUserSetting::where('component', DefaultColumnsPostDataTable::class)->where('is_layout', true)->count())->toBe(0)
+                    ->and(DatatableUserSetting::where('is_default_columns', true)->count())->toBe(1);
+            });
+
+            it('keeps is_layout rows when flag is false (default)', function (): void {
+                DatatableUserSetting::create([
+                    'name' => 'OtherUserLayout',
+                    'component' => DefaultColumnsPostDataTable::class,
+                    'cache_key' => DefaultColumnsPostDataTable::class,
+                    'settings' => ['enabledCols' => ['id']],
+                    'is_layout' => true,
+                    'is_default_columns' => false,
+                    'is_permanent' => false,
+                    'authenticatable_id' => $this->otherUser->getKey(),
+                    'authenticatable_type' => get_class($this->otherUser),
+                ]);
+
+                Livewire::test(DefaultColumnsPostDataTable::class)
+                    ->call('loadData')
+                    ->set('enabledCols', ['id', 'title'])
+                    ->call('saveDefaultColumns');
+
+                expect(DatatableUserSetting::where('component', DefaultColumnsPostDataTable::class)->where('is_layout', true)->count())->toBe(1);
+            });
+
+            it('does not delete saved filter rows (is_layout=false) when flag is true', function (): void {
+                DatatableUserSetting::create([
+                    'name' => 'My filter',
+                    'component' => DefaultColumnsPostDataTable::class,
+                    'cache_key' => DefaultColumnsPostDataTable::class,
+                    'settings' => ['userFilters' => []],
+                    'is_layout' => false,
+                    'is_default_columns' => false,
+                    'is_permanent' => false,
+                    'authenticatable_id' => $this->otherUser->getKey(),
+                    'authenticatable_type' => get_class($this->otherUser),
+                ]);
+
+                Livewire::test(DefaultColumnsPostDataTable::class)
+                    ->call('loadData')
+                    ->set('enabledCols', ['id', 'title'])
+                    ->call('saveDefaultColumns', true);
+
+                expect(DatatableUserSetting::where('name', 'My filter')->count())->toBe(1);
+            });
+
+            it('does not touch layouts of unrelated components when flag is true', function (): void {
+                DatatableUserSetting::create([
+                    'name' => 'UnrelatedLayout',
+                    'component' => PostDataTable::class,
+                    'cache_key' => PostDataTable::class,
+                    'settings' => ['enabledCols' => ['id']],
+                    'is_layout' => true,
+                    'is_default_columns' => false,
+                    'is_permanent' => false,
+                    'authenticatable_id' => $this->otherUser->getKey(),
+                    'authenticatable_type' => get_class($this->otherUser),
+                ]);
+
+                Livewire::test(DefaultColumnsPostDataTable::class)
+                    ->call('loadData')
+                    ->set('enabledCols', ['id', 'title'])
+                    ->call('saveDefaultColumns', true);
+
+                expect(DatatableUserSetting::where('component', PostDataTable::class)->where('is_layout', true)->count())->toBe(1);
+            });
+
+            it('silently no-ops when gate is false even with reset flag', function (): void {
+                DatatableUserSetting::create([
+                    'name' => 'OtherUserLayout',
+                    'component' => PostDataTable::class,
+                    'cache_key' => PostDataTable::class,
+                    'settings' => ['enabledCols' => ['id']],
+                    'is_layout' => true,
+                    'is_default_columns' => false,
+                    'is_permanent' => false,
+                    'authenticatable_id' => $this->otherUser->getKey(),
+                    'authenticatable_type' => get_class($this->otherUser),
+                ]);
+
+                Livewire::test(PostDataTable::class)
+                    ->call('loadData')
+                    ->call('saveDefaultColumns', true);
+
+                expect(DatatableUserSetting::where('component', PostDataTable::class)->where('is_layout', true)->count())->toBe(1)
+                    ->and(DatatableUserSetting::where('is_default_columns', true)->count())->toBe(0);
+            });
         });
 
         it('overwrites default set by another user', function (): void {

--- a/tests/Feature/DefaultColumnsTest.php
+++ b/tests/Feature/DefaultColumnsTest.php
@@ -29,6 +29,20 @@ describe('Global Default Columns', function (): void {
                 ->assertSee(__('Set as Default'));
         });
 
+        it('renders Set as Default button with wire:click parentheses (Livewire v4)', function (): void {
+            $html = Livewire::test(DefaultColumnsPostDataTable::class)->html();
+
+            expect($html)->toContain('wire:click="saveDefaultColumns()"')
+                ->and($html)->not->toContain('wire:click="saveDefaultColumns"');
+        });
+
+        it('renders Reset Layout button with $wire-prefixed method call (Livewire v4)', function (): void {
+            $html = Livewire::test(DefaultColumnsPostDataTable::class)->html();
+
+            expect($html)->toContain('x-on:click="$wire.resetLayout()"')
+                ->and($html)->not->toContain('x-on:click="resetLayout"');
+        });
+
         it('silently no-ops saveDefaultColumns when gate is false', function (): void {
             Livewire::test(PostDataTable::class)
                 ->call('loadData')

--- a/tests/Feature/LivewireV4DirectivesAuditTest.php
+++ b/tests/Feature/LivewireV4DirectivesAuditTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Symfony\Component\Finder\Finder;
+
+it('has no bare wire:click directives without parentheses in blade views', function (): void {
+    $finder = (new Finder())
+        ->files()
+        ->in(__DIR__ . '/../../resources/views')
+        ->name('*.blade.php');
+
+    $offenders = [];
+
+    foreach ($finder as $file) {
+        $content = $file->getContents();
+
+        if (preg_match_all('/wire:click="([a-zA-Z_][a-zA-Z0-9_]*)"/', $content, $matches)) {
+            foreach ($matches[0] as $match) {
+                $offenders[] = $file->getRelativePathname() . ' :: ' . $match;
+            }
+        }
+    }
+
+    expect($offenders)->toBe([], implode("\n", $offenders));
+});
+
+it('has no bare x-on:click directives referencing $wire methods without prefix', function (): void {
+    $finder = (new Finder())
+        ->files()
+        ->in(__DIR__ . '/../../resources/views')
+        ->name('*.blade.php');
+
+    $offenders = [];
+    $wireMethods = [
+        'resetLayout',
+        'saveDefaultColumns',
+        'deleteDefaultColumns',
+        'saveFilter',
+        'loadFilter',
+        'clearFilters',
+        'clearFiltersAndSort',
+        'storeColLayout',
+        'deleteSavedFilter',
+        'updateSavedFilter',
+    ];
+
+    foreach ($finder as $file) {
+        $content = $file->getContents();
+
+        foreach ($wireMethods as $method) {
+            if (preg_match('/x-on:click="' . preg_quote($method, '/') . '"/', $content)) {
+                $offenders[] = $file->getRelativePathname() . ' :: x-on:click="' . $method . '"';
+            }
+        }
+    }
+
+    expect($offenders)->toBe([], implode("\n", $offenders));
+});


### PR DESCRIPTION
## Summary

Two related changes around the column-default workflow:

1. **Fix bare `wire:click` / `x-on:click` directives.** Replace `wire:click="method"` and `x-on:click="method"` with explicit method invocations. Affects **Set as Default**, **Reset Layout**, **Clear filters and sort**, **Clear all filters**. Under Livewire v4 / Alpine v3, the bare form silently did nothing — most visibly: no `is_default_columns` row ever got written to `datatable_user_settings`.
2. **Prompt on Set as Default to reset other users' layouts.** Clicking Set as Default now opens a TallStackUI dialog with two action buttons: `Save default and reset others` (deletes every `is_layout=true` row for the same component so the new default applies everywhere on next mount) and `Save default only` (current behaviour). Saved filters (`is_layout=false`) are never touched. Closing the dialog leaves everything unchanged. `saveDefaultColumns` gains an optional `bool $resetOtherUserLayouts = false` parameter — fully back-compat for existing callers.

Adds an audit test that scans `resources/views` for bare `wire:click` and bare `x-on:click` references to known `$wire` methods to prevent regression of (1).