### PR TITLE
fix: guard echo listener setup against missing broadcastChannels property

### DIFF
--- a/dist/build/manifest.json
+++ b/dist/build/manifest.json
@@ -9,7 +9,7 @@
     "isEntry": true
   },
   "resources/js/tall-datatables.js": {
-    "file": "assets/tall-datatables-CuHzzV6d.js",
+    "file": "assets/tall-datatables-C4KhvyB2.js",
     "name": "tall-datatables",
     "src": "resources/js/tall-datatables.js",
     "isEntry": true

--- a/resources/js/components/data-table.js
+++ b/resources/js/components/data-table.js
@@ -14,12 +14,15 @@ export default function data_table() {
             this.textFilterRows = this._computeTextFilterRows();
 
             this._disposers.push(
-                this.$watch(() => JSON.stringify(this.$wire.textFilters), () => {
-                    const serverRows = this._computeTextFilterRows();
-                    if (serverRows.length < this.textFilterRows.length) {
-                        this.textFilterRows = serverRows;
-                    }
-                }),
+                this.$watch(
+                    () => JSON.stringify(this.$wire.textFilters),
+                    () => {
+                        const serverRows = this._computeTextFilterRows();
+                        if (serverRows.length < this.textFilterRows.length) {
+                            this.textFilterRows = serverRows;
+                        }
+                    },
+                ),
             );
 
             this._setupEchoListeners();
@@ -148,24 +151,35 @@ export default function data_table() {
                 return;
             }
 
+            // Components without HasEloquentListeners have no
+            // broadcastChannels property; accessing it through $wire would
+            // make Livewire treat the access as a server-side method call.
+            const componentData = this.$wire.__instance?.ephemeral;
+            if (!componentData || !('broadcastChannels' in componentData)) {
+                return;
+            }
+
             const initial = this.$wire.broadcastChannels || {};
             Object.values(initial).forEach((channel) =>
                 this._subscribeChannel(channel),
             );
 
             this._disposers.push(
-                this.$watch('$wire.broadcastChannels', (newChannels, oldChannels) => {
-                    const newValues = Object.values(newChannels || {});
-                    const oldValues = Object.values(oldChannels || {});
+                this.$watch(
+                    '$wire.broadcastChannels',
+                    (newChannels, oldChannels) => {
+                        const newValues = Object.values(newChannels || {});
+                        const oldValues = Object.values(oldChannels || {});
 
-                    oldValues
-                        .filter((ch) => !newValues.includes(ch))
-                        .forEach((ch) => this._leaveChannel(ch));
+                        oldValues
+                            .filter((ch) => !newValues.includes(ch))
+                            .forEach((ch) => this._leaveChannel(ch));
 
-                    newValues
-                        .filter((ch) => !oldValues.includes(ch))
-                        .forEach((ch) => this._subscribeChannel(ch));
-                }),
+                        newValues
+                            .filter((ch) => !oldValues.includes(ch))
+                            .forEach((ch) => this._subscribeChannel(ch));
+                    },
+                ),
             );
         },
 
@@ -193,9 +207,7 @@ export default function data_table() {
                 return;
             }
 
-            this._echoChannels.forEach((channel) =>
-                window.Echo.leave(channel),
-            );
+            this._echoChannels.forEach((channel) => window.Echo.leave(channel));
             this._echoChannels = [];
         },
     };

--- a/tests/Browser/EchoListenersBrowserTest.php
+++ b/tests/Browser/EchoListenersBrowserTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Browser tests for the Echo listener setup in data-table.js.
+ *
+ * Components without the HasEloquentListeners trait have no public
+ * broadcastChannels property. Accessing it through $wire makes Livewire
+ * treat the access as a method call, which fails server-side with a
+ * MethodNotFoundException. The echo setup must therefore check that the
+ * property exists before touching it.
+ */
+
+use Tests\Fixtures\Livewire\EchoBroadcastablePostDataTable;
+use Tests\Fixtures\Livewire\EchoPlainPostDataTable;
+use Tests\Fixtures\Models\BroadcastablePost;
+
+beforeEach(function (): void {
+    $manifestPath = dirname(__DIR__, 2) . '/dist/build/manifest.json';
+    if (! file_exists($manifestPath)) {
+        $this->markTestSkipped('Browser tests require built assets. Run: npm run build');
+    }
+
+    createTestUser(['name' => 'Test User', 'email' => 'test@example.com']);
+});
+
+describe('Echo Listeners', function (): void {
+    it('does not probe broadcastChannels on components without the trait', function (): void {
+        createTestPost(['title' => 'Plain Echo Post']);
+
+        $page = visitLivewire(EchoPlainPostDataTable::class);
+
+        $page->assertSee('Plain Echo Post')
+            ->wait(1)
+            ->assertNoJavascriptErrors();
+
+        $result = $page->script('() => ({
+            broadcastCalls: window.__lwBroadcastCalls.length,
+            channels: window.__echoChannels.length,
+        })');
+
+        expect($result['broadcastCalls'])->toBe(0)
+            ->and($result['channels'])->toBe(0);
+    });
+
+    it('subscribes to broadcast channels when the trait is present', function (): void {
+        $post = BroadcastablePost::create([
+            'user_id' => createTestUser()->getKey(),
+            'title' => 'Broadcastable Echo Post',
+            'content' => 'Broadcastable content',
+            'is_published' => true,
+        ]);
+
+        $page = visitLivewire(EchoBroadcastablePostDataTable::class);
+
+        $page->assertSee('Broadcastable Echo Post')
+            ->wait(1)
+            ->assertNoJavascriptErrors();
+
+        $channels = $page->script('() => window.__echoChannels');
+
+        expect($channels)->toContain($post->broadcastChannel());
+    });
+});

--- a/tests/Fixtures/Livewire/EchoBroadcastablePostDataTable.php
+++ b/tests/Fixtures/Livewire/EchoBroadcastablePostDataTable.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Fixtures\Livewire;
+
+use Livewire\Attributes\Layout;
+use TeamNiftyGmbH\DataTable\DataTable;
+use TeamNiftyGmbH\DataTable\Traits\HasEloquentListeners;
+use Tests\Fixtures\Models\BroadcastablePost;
+
+#[Layout('components.layouts.echo-app')]
+class EchoBroadcastablePostDataTable extends DataTable
+{
+    use HasEloquentListeners;
+
+    public array $enabledCols = [
+        'title',
+        'content',
+        'is_published',
+        'created_at',
+    ];
+
+    protected string $model = BroadcastablePost::class;
+}

--- a/tests/Fixtures/Livewire/EchoPlainPostDataTable.php
+++ b/tests/Fixtures/Livewire/EchoPlainPostDataTable.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Fixtures\Livewire;
+
+use Livewire\Attributes\Layout;
+use TeamNiftyGmbH\DataTable\DataTable;
+use Tests\Fixtures\Models\Post;
+
+/**
+ * Data table without HasEloquentListeners rendered with window.Echo present.
+ * Used to ensure the echo listener setup does not probe the missing
+ * broadcastChannels property, which Livewire would treat as a method call.
+ */
+#[Layout('components.layouts.echo-app')]
+class EchoPlainPostDataTable extends DataTable
+{
+    public array $enabledCols = [
+        'title',
+        'content',
+        'is_published',
+        'created_at',
+    ];
+
+    protected string $model = Post::class;
+}

--- a/tests/resources/views/components/layouts/echo-app.blade.php
+++ b/tests/resources/views/components/layouts/echo-app.blade.php
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="csrf-token" content="{{ csrf_token() }}" />
+        <title>DataTable Echo Browser Test</title>
+        <script>
+            window.__echoChannels = [];
+            window.__lwBroadcastCalls = [];
+
+            window.Echo = {
+                socketId() {
+                    return '1234.5678';
+                },
+                private(channel) {
+                    window.__echoChannels.push(channel);
+
+                    return {
+                        listenToAll() {
+                            return this;
+                        },
+                        listen() {
+                            return this;
+                        },
+                    };
+                },
+                leave(channel) {
+                    window.__echoChannels = window.__echoChannels.filter(
+                        (ch) => ch !== channel,
+                    );
+                },
+            };
+
+            const originalFetch = window.fetch;
+            window.fetch = function (...args) {
+                const body = args[1]?.body;
+                if (
+                    typeof body === 'string' &&
+                    body.includes('broadcastChannels')
+                ) {
+                    window.__lwBroadcastCalls.push(body);
+                }
+
+                return originalFetch.apply(this, args);
+            };
+        </script>
+        @tallStackUiStyle
+        @dataTableStyles
+        @livewireStyles
+    </head>
+    <body class="antialiased">
+        {{ $slot }}
+
+        @livewireScripts
+        @tallStackUiScript
+        @dataTablesScripts
+    </body>
+</html>


### PR DESCRIPTION
## Summary

Since the echo listener setup landed, `data-table.js` unconditionally reads `$wire.broadcastChannels` (initial read + `$watch`). On components that do not use the `HasEloquentListeners` trait, that property does not exist — Livewire's `$wire` proxy then treats the access as a method call, Alpine's evaluator auto-invokes it, and the server responds with a `MethodNotFoundException` (500) on every page using such a data table as soon as `window.Echo` is defined.

This affects every consuming app on >= 2.4.22 whose data tables don't use the trait.

## Fix

`_setupEchoListeners()` now checks the component's ephemeral data for the `broadcastChannels` property before touching it and bails out early when it is absent.

## Tests

New browser tests with a stubbed `window.Echo` and a fetch spy:
- a data table without the trait renders without any `broadcastChannels` server roundtrip or JS errors (reproduces the original `MethodNotFoundException` before the fix)
- a data table with the trait still subscribes to its model broadcast channels