### PR TITLE
Add whereDoesntHave semantics for negated relation filters

### DIFF
--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -88,10 +88,30 @@ trait BuildsQueries
                 $filter['column'] = $column;
                 $filter['relation'] = Str::camel($relation);
 
+                $negatedRelationOperators = [
+                    '!=' => '=',
+                    'not like' => 'like',
+                    'not in' => 'in',
+                    'does not contain' => 'contains',
+                ];
+
                 if ($filter['value'] === '%*%') {
                     $this->applyFilterWhereHas($query, $filter['relation']);
                 } elseif ($filter['value'] === '%!*%') {
                     $this->applyFilterWhereDoesntHave($query, $filter['relation']);
+                } elseif (array_key_exists($filter['operator'] ?? '', $negatedRelationOperators)) {
+                    $filter['operator'] = $negatedRelationOperators[$filter['operator']];
+
+                    try {
+                        $query->whereDoesntHave($filter['relation'], function (Builder $subQuery) use ($type, $filter) {
+                            unset($filter['relation']);
+                            $this->addFilter($subQuery, $type, $filter);
+
+                            return $subQuery;
+                        });
+                    } catch (BadMethodCallException) {
+                        // Relation does not exist on model — skip this filter
+                    }
                 } else {
                     try {
                         $query->whereHas($filter['relation'], function (Builder $subQuery) use ($type, $filter) {

--- a/tests/Feature/RelationNegationFilterTest.php
+++ b/tests/Feature/RelationNegationFilterTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use Livewire\Livewire;
+use Tests\Fixtures\Livewire\PostDataTable;
+use Tests\Fixtures\Models\Tag;
+
+beforeEach(function (): void {
+    $this->user = createTestUser();
+    $this->actingAs($this->user);
+});
+
+describe('Negation operators on to-many relation columns', function (): void {
+    it('excludes rows that have a matching related record, including rows with no related records', function (): void {
+        $reisebuero = Tag::create(['name' => 'Reisebüro']);
+        $request = Tag::create(['name' => 'Kat-Anfrage']);
+
+        $onlyReisebuero = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Only Reisebüro']);
+        $onlyReisebuero->tags()->attach($reisebuero);
+
+        $reisebueroAndOther = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Reisebüro And Other']);
+        $reisebueroAndOther->tags()->attach([$reisebuero->getKey(), $request->getKey()]);
+
+        $otherOnly = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Other Only']);
+        $otherOnly->tags()->attach($request);
+
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => 'No Tags']);
+
+        $component = Livewire::test(PostDataTable::class)
+            ->set('enabledCols', ['title'])
+            ->set('userFilters', [
+                [['column' => 'tags.name', 'operator' => '!=', 'value' => 'Reisebüro']],
+            ])
+            ->call('loadData');
+
+        $data = $component->instance()->getDataForTesting();
+        $titles = collect($data['data'])->pluck('title')->all();
+
+        expect($data['total'])->toBe(2)
+            ->and($titles)->toContain('Other Only')
+            ->and($titles)->toContain('No Tags')
+            ->and($titles)->not->toContain('Only Reisebüro')
+            ->and($titles)->not->toContain('Reisebüro And Other');
+    });
+
+    it('excludes rows whose related record is in the negated list with the not in operator', function (): void {
+        $reisebuero = Tag::create(['name' => 'Reisebüro']);
+        $wholesale = Tag::create(['name' => 'Direktkunde']);
+        $request = Tag::create(['name' => 'Kat-Anfrage']);
+
+        $reise = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Reisebüro Post']);
+        $reise->tags()->attach($reisebuero);
+
+        $direkt = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Direktkunde Post']);
+        $direkt->tags()->attach($wholesale);
+
+        $keep = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Keep Post']);
+        $keep->tags()->attach($request);
+
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => 'No Tags']);
+
+        $component = Livewire::test(PostDataTable::class)
+            ->set('enabledCols', ['title'])
+            ->set('userFilters', [
+                [['column' => 'tags.name', 'operator' => 'not in', 'value' => 'Reisebüro, Direktkunde']],
+            ])
+            ->call('loadData');
+
+        $data = $component->instance()->getDataForTesting();
+        $titles = collect($data['data'])->pluck('title')->all();
+
+        expect($data['total'])->toBe(2)
+            ->and($titles)->toContain('Keep Post')
+            ->and($titles)->toContain('No Tags')
+            ->and($titles)->not->toContain('Reisebüro Post')
+            ->and($titles)->not->toContain('Direktkunde Post');
+    });
+
+    it('excludes rows whose related record matches with the does not contain operator', function (): void {
+        $reisebuero = Tag::create(['name' => 'Reisebüro Süd']);
+        $request = Tag::create(['name' => 'Kat-Anfrage']);
+
+        $reise = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Has Reisebüro']);
+        $reise->tags()->attach($reisebuero);
+
+        $keep = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Keep Post']);
+        $keep->tags()->attach($request);
+
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => 'No Tags']);
+
+        $component = Livewire::test(PostDataTable::class)
+            ->set('enabledCols', ['title'])
+            ->set('userFilters', [
+                [['column' => 'tags.name', 'operator' => 'does not contain', 'value' => 'Reisebüro']],
+            ])
+            ->call('loadData');
+
+        $data = $component->instance()->getDataForTesting();
+        $titles = collect($data['data'])->pluck('title')->all();
+
+        expect($data['total'])->toBe(2)
+            ->and($titles)->not->toContain('Has Reisebüro');
+    });
+
+    it('still uses whereHas for positive operators so only matching rows remain', function (): void {
+        $reisebuero = Tag::create(['name' => 'Reisebüro']);
+        $request = Tag::create(['name' => 'Kat-Anfrage']);
+
+        $reise = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Reisebüro Post']);
+        $reise->tags()->attach($reisebuero);
+
+        $other = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Other Post']);
+        $other->tags()->attach($request);
+
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => 'No Tags']);
+
+        $component = Livewire::test(PostDataTable::class)
+            ->set('enabledCols', ['title'])
+            ->set('userFilters', [
+                [['column' => 'tags.name', 'operator' => '=', 'value' => 'Reisebüro']],
+            ])
+            ->call('loadData');
+
+        $data = $component->instance()->getDataForTesting();
+        $titles = collect($data['data'])->pluck('title')->all();
+
+        expect($data['total'])->toBe(1)
+            ->and($titles)->toContain('Reisebüro Post');
+    });
+});


### PR DESCRIPTION
## Problem

Negation operators (`!=`, `not like`, `not in`, `does not contain`) on a to-many relation column were always compiled into a `whereHas` clause with the negated condition inside. For a multi-value relation this means "has at least one related row that does not match", which:

- does not exclude rows that also have a related row matching the value (e.g. a record tagged both `Reisebüro` and `Kat-Anfrage` survives a `tags.name != Reisebüro` filter), and
- drops rows that have no related rows at all.

There was no way in the filter UI to express "rows that do not have a related record matching X".

## Change

Negation operators on a relation column now compile to `whereDoesntHave` with the positive counterpart of the operator applied inside the closure:

| Operator | Inner condition |
| --- | --- |
| `!=` | `=` |
| `not like` | `like` |
| `not in` | `in` |
| `does not contain` | `contains` |

A negated relation filter now returns every row that does not have a related record matching the value, including rows without any related records. Positive operators keep using `whereHas`.

This is a behavior change for negated relation filters.