### PR TITLE
Retrieve only keys for non-highlighted Scout searches

### DIFF
--- a/src/DataTableServiceProvider.php
+++ b/src/DataTableServiceProvider.php
@@ -115,20 +115,30 @@ class DataTableServiceProvider extends ServiceProvider
             Builder::macro('getScoutResults',
                 function (array $highlight = ['*'], int $perPage = 20, int $page = 0) {
                     /** @var Builder $this */
-                    $searchResult = $this->options(
-                        [
-                            'attributesToHighlight' => array_values($highlight),
-                            'highlightPreTag' => '<mark>',
-                            'highlightPostTag' => '</mark>',
-                            'limit' => $perPage,
-                            'offset' => max(($page - 1) * $perPage, 0),
-                        ])
-                        ->raw();
+                    $keyName = $this->model->getKeyName();
 
-                    $hits = Arr::keyBy(data_get($searchResult, 'hits'), $this->model->getKeyName());
+                    $options = [
+                        'limit' => $perPage,
+                        'offset' => max(($page - 1) * $perPage, 0),
+                    ];
+
+                    if ($highlight === []) {
+                        // No highlighting requested (e.g. an over-fetch that only needs the
+                        // ids): retrieve just the primary key so large limits don't pull full
+                        // highlighted documents into memory.
+                        $options['attributesToRetrieve'] = [$keyName];
+                    } else {
+                        $options['attributesToHighlight'] = array_values($highlight);
+                        $options['highlightPreTag'] = '<mark>';
+                        $options['highlightPostTag'] = '</mark>';
+                    }
+
+                    $searchResult = $this->options($options)->raw();
+
+                    $hits = Arr::keyBy(data_get($searchResult, 'hits'), $keyName);
                     unset($searchResult['hits']);
 
-                    $ids = collect($hits)->pluck($this->model->getKeyName())->all();
+                    $ids = collect($hits)->pluck($keyName)->all();
 
                     return [
                         'hits' => $hits,

--- a/tests/Feature/ServiceProviderTest.php
+++ b/tests/Feature/ServiceProviderTest.php
@@ -522,6 +522,28 @@ describe('DataTableServiceProvider', function (): void {
                 ->toHaveKey('ids')
                 ->toHaveKey('searchResult');
         });
+
+        it('getScoutResults macro retrieves only keys when highlight is empty', function (): void {
+            if (! class_exists(Laravel\Scout\Builder::class)) {
+                $this->markTestSkipped('Scout not installed');
+            }
+
+            config(['scout.driver' => 'collection']);
+
+            Tests\Fixtures\Models\SearchablePost::create([
+                'user_id' => createTestUser()->getKey(),
+                'title' => 'Ids Only Post',
+                'content' => 'Some content',
+                'is_published' => true,
+            ]);
+
+            $result = Tests\Fixtures\Models\SearchablePost::search('Ids')->getScoutResults(highlight: []);
+
+            expect($result)->toBeArray()
+                ->toHaveKey('hits')
+                ->toHaveKey('ids')
+                ->toHaveKey('searchResult');
+        });
     });
 
     describe('Blade directive rendering via Blade::compileString', function (): void {


### PR DESCRIPTION
## Problem

`getScoutResults` always requested `attributesToHighlight: ['*']`, so Meilisearch returned every matching document together with a fully highlighted copy of **all** attributes (including large text fields). A caller that only needs the ids — e.g. the search controller's over-fetch of up to 1000 candidates, whose highlights are then discarded — loaded up to `limit` full highlighted documents into memory for nothing. On a memory-constrained worker this is enough to exhaust the limit and 500.

## Change

When the `highlight` array is empty, request `attributesToRetrieve: [<primaryKey>]` and skip highlighting, so only the keys come back. Existing callers (data tables, which pass their enabled columns) keep their current behaviour and highlighting unchanged.