### PR TITLE
Cap to-many relation columns to bound eager-load memory

### DIFF
--- a/config/tall-datatables.php
+++ b/config/tall-datatables.php
@@ -29,6 +29,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Max Relation Column Values
+    |--------------------------------------------------------------------------
+    |
+    | When a to-many relation attribute is enabled as a column (e.g. orders.total),
+    | the relation is eager loaded for every row. Without a bound a single row can
+    | pull thousands of related records into memory and exhaust the worker. This
+    | caps how many related records are loaded per parent for such columns.
+    | Set to 0 to disable the cap.
+    |
+    */
+
+    'max_relation_column_values' => env('TALL_DATATABLES_MAX_RELATION_COLUMN_VALUES', 50),
+
+    /*
+    |--------------------------------------------------------------------------
     | Search Route
     |--------------------------------------------------------------------------
     |

--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -7,6 +7,11 @@ use Carbon\Exceptions\InvalidFormatException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\QueryException;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -182,6 +187,40 @@ trait BuildsQueries
         );
     }
 
+    /**
+     * Apply the resolved eager loads, capping to-many relation columns to a configurable
+     * number of records per parent so a single row can never pull thousands of related
+     * records into memory and exhaust the worker.
+     *
+     * @param  array<int, string>  $with  list of "relation:col1,col2" eager-load strings
+     */
+    protected function applyEagerLoadsWithRelationLimit(Builder $query, array $with): void
+    {
+        $cap = (int) config('tall-datatables.max_relation_column_values', 50);
+
+        foreach ($with as $eagerLoad) {
+            [$path, $columns] = array_pad(explode(':', $eagerLoad, 2), 2, null);
+
+            if ($cap <= 0 || ! $this->relationPathIsToMany($path)) {
+                $query->with($eagerLoad);
+
+                continue;
+            }
+
+            $select = $columns !== null && $columns !== '*'
+                ? array_values(array_filter(explode(',', $columns)))
+                : null;
+
+            $query->with([$path => function ($relationQuery) use ($select, $cap): void {
+                if ($select) {
+                    $relationQuery->select($select);
+                }
+
+                $relationQuery->limit($cap);
+            }]);
+        }
+    }
+
     protected function applyFormatters(array &$itemArray, Model $item, array $context): void
     {
         $formatters = $this->getResolvedFormatters($item);
@@ -290,7 +329,7 @@ trait BuildsQueries
         $this->enabledCols = $enabledCols;
         $this->formatters = array_merge($formatters, $this->formatters);
 
-        $query->with($with);
+        $this->applyEagerLoadsWithRelationLimit($query, $with);
         $query->select(array_merge($select, [$this->modelTable . '.' . $this->modelKeyName]));
 
         if (! empty($this->withCountRelations)) {
@@ -709,6 +748,31 @@ trait BuildsQueries
             : $filter['value'];
 
         return $filter;
+    }
+
+    /**
+     * Determine whether the leaf relation of a (possibly nested) eager-load path is a
+     * to-many relation, i.e. one that can return an unbounded number of records per parent.
+     */
+    protected function relationPathIsToMany(string $path): bool
+    {
+        $model = app($this->getModel());
+        $relation = null;
+
+        foreach (explode('.', $path) as $segment) {
+            try {
+                $relation = $model->{Str::camel($segment)}();
+                $model = $relation->getRelated();
+            } catch (Throwable) {
+                return false;
+            }
+        }
+
+        return $relation instanceof HasMany
+            || $relation instanceof HasManyThrough
+            || $relation instanceof BelongsToMany
+            || $relation instanceof MorphMany
+            || $relation instanceof MorphToMany;
     }
 
     private function applyFallbackSearch(Builder $query, string $search): void

--- a/tests/Feature/RelationColumnLimitTest.php
+++ b/tests/Feature/RelationColumnLimitTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Livewire\Livewire;
+use Tests\Fixtures\Livewire\PostWithCommentsDataTable;
+use Tests\Fixtures\Livewire\PostWithRelationsDataTable;
+
+beforeEach(function (): void {
+    $this->user = createTestUser();
+    $this->actingAs($this->user);
+});
+
+function commentValues(array $row): array
+{
+    $cell = $row['comments.body'] ?? [];
+    if (is_array($cell) && array_key_exists('raw', $cell)) {
+        $cell = $cell['raw'];
+    }
+
+    return is_array($cell) ? $cell : [$cell];
+}
+
+it('caps a to-many relation column per parent row', function (): void {
+    config(['tall-datatables.max_relation_column_values' => 50]);
+
+    foreach (range(1, 2) as $p) {
+        $post = createTestPost(['user_id' => $this->user->getKey(), 'title' => "Post {$p}"]);
+        foreach (range(1, 60) as $i) {
+            createTestComment(['post_id' => $post->getKey(), 'user_id' => $this->user->getKey()]);
+        }
+    }
+
+    $data = Livewire::test(PostWithCommentsDataTable::class)->instance()->getDataForTesting();
+
+    expect($data['data'])->toHaveCount(2);
+    foreach ($data['data'] as $row) {
+        expect(count(commentValues($row)))->toBeLessThanOrEqual(50);
+    }
+});
+
+it('does not cap when the limit is disabled', function (): void {
+    config(['tall-datatables.max_relation_column_values' => 0]);
+
+    $post = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Uncapped']);
+    foreach (range(1, 60) as $i) {
+        createTestComment(['post_id' => $post->getKey(), 'user_id' => $this->user->getKey()]);
+    }
+
+    $data = Livewire::test(PostWithCommentsDataTable::class)->instance()->getDataForTesting();
+
+    expect(count(commentValues($data['data'][0])))->toBe(60);
+});
+
+it('leaves to-one relation columns untouched', function (): void {
+    config(['tall-datatables.max_relation_column_values' => 50]);
+
+    createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Has User']);
+
+    $data = Livewire::test(PostWithRelationsDataTable::class)->instance()->getDataForTesting();
+
+    expect($data['data'][0])->toHaveKey('user.name');
+});


### PR DESCRIPTION
## Problem

When a **to-many** relation attribute is enabled as a column (e.g. `orders.updated_at`), the relation is eager loaded for every row with no bound. A single parent row can therefore pull *all* of its related records into the row payload. On a list where a few rows have thousands of related records, this allocates hundreds of MB during render and exhausts the worker (HTTP 500), even though the visible data is tiny.

## Change

Cap the eager load to a configurable number of records **per parent** for to-many relation columns:

- New config `tall-datatables.max_relation_column_values` (default **50**, `0` disables).
- To-one relation columns (`BelongsTo`, etc.) are untouched.
- Applied at the point the eager loads are attached, by detecting whether the leaf relation of each `with` path is to-many — so the `constructWith` cache stays serializable (no closures cached).
- Uses Laravel's native per-parent eager-load limiting.

Memory for such columns is now bounded regardless of how many related records exist; the content no longer decides whether the page crashes.

Tests cover: per-parent cap (each row ≤ limit), cap disabled loads all, and to-one columns unaffected.