### PR TITLE
Export mixed to-one/to-many relation columns correctly

### DIFF
--- a/src/Exports/Concerns/ExportsData.php
+++ b/src/Exports/Concerns/ExportsData.php
@@ -37,14 +37,13 @@ trait ExportsData
             $value = data_get($rowArray, $column);
 
             if (is_null($value) && str_contains($column, '.')) {
-                $parts = explode('.', $column);
-                $lastPart = array_pop($parts);
-
-                $wildcardKey = implode('.*.', $parts) . '.*.' . $lastPart;
-                $value = data_get($rowArray, $wildcardKey);
+                $value = $this->extractNestedValue($rowArray, explode('.', $column));
 
                 if (is_array($value)) {
-                    $value = implode('; ', array_filter($value));
+                    $value = implode('; ', array_filter(
+                        $value,
+                        fn ($item) => $item !== null && $item !== ''
+                    ));
                 }
             }
 
@@ -62,5 +61,39 @@ trait ExportsData
         }
 
         return $result;
+    }
+
+    /**
+     * Resolve a dotted column path against a row array, descending through to-one segments
+     * and mapping over to-many (list) segments at any position. This handles mixed paths such
+     * as contact.contactTopics.name (a to-one relation followed by a to-many relation), which a
+     * uniform wildcard cannot express.
+     *
+     * @param  array<int, string>  $segments
+     */
+    protected function extractNestedValue(mixed $data, array $segments): mixed
+    {
+        if ($segments === []) {
+            return $data;
+        }
+
+        if (is_array($data) && array_is_list($data)) {
+            $values = [];
+            foreach ($data as $item) {
+                $resolved = $this->extractNestedValue($item, $segments);
+
+                if (is_array($resolved)) {
+                    $values = array_merge($values, $resolved);
+                } elseif (! is_null($resolved)) {
+                    $values[] = $resolved;
+                }
+            }
+
+            return $values;
+        }
+
+        $segment = array_shift($segments);
+
+        return $this->extractNestedValue(data_get($data, $segment), $segments);
     }
 }

--- a/tests/Feature/ExportNestedRelationTest.php
+++ b/tests/Feature/ExportNestedRelationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use TeamNiftyGmbH\DataTable\Exports\DataTableExport;
+use Tests\Fixtures\Models\Post;
+
+beforeEach(function (): void {
+    $this->user = createTestUser();
+    $this->actingAs($this->user);
+});
+
+it('exports a to-one then to-many nested relation column', function (): void {
+    $owner = createTestUser(['name' => 'Owner']);
+    createTestComment(['user_id' => $owner->getKey(), 'body' => 'Topic A']);
+    createTestComment(['user_id' => $owner->getKey(), 'body' => 'Topic B']);
+
+    $post = createTestPost(['user_id' => $owner->getKey(), 'title' => 'Nested']);
+    $post = Post::query()->with('user.comments')->find($post->getKey());
+
+    $export = new DataTableExport(Post::query(), ['user.comments.body']);
+    $row = $export->mapRow($post);
+
+    expect($row['user.comments.body'])->toBeString()
+        ->toContain('Topic A')
+        ->toContain('Topic B');
+});
+
+it('still exports a single-level to-many relation column', function (): void {
+    $post = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'WithComments']);
+    createTestComment(['post_id' => $post->getKey(), 'user_id' => $this->user->getKey(), 'body' => 'First']);
+    createTestComment(['post_id' => $post->getKey(), 'user_id' => $this->user->getKey(), 'body' => 'Second']);
+
+    $post = Post::query()->with('comments')->find($post->getKey());
+
+    $export = new DataTableExport(Post::query(), ['comments.body']);
+    $row = $export->mapRow($post);
+
+    expect($row['comments.body'])->toContain('First')->toContain('Second');
+});
+
+it('exports a plain to-one relation column unchanged', function (): void {
+    $owner = createTestUser(['name' => 'Solo Owner']);
+    $post = createTestPost(['user_id' => $owner->getKey(), 'title' => 'Solo']);
+    $post = Post::query()->with('user')->find($post->getKey());
+
+    $export = new DataTableExport(Post::query(), ['user.name']);
+    $row = $export->mapRow($post);
+
+    expect($row['user.name'])->toBe('Solo Owner');
+});


### PR DESCRIPTION
## Problem

A relation column whose path mixes a **to-one** and a **to-many** segment — e.g. `contact.contactTopics.name` (a `BelongsTo` contact, then a to-many topics relation) — is shown correctly in the list but comes out **empty in the export**.

`mapRow`'s fallback for null values built a uniform wildcard key by inserting `*` after *every* segment: `contact.*.contactTopics.*.name`. Since `contact` is to-one (an associative array, not a list), `contact.*` matches nothing, so the lookup returns null and the cell is blank.

## Fix

Resolve the dotted path recursively: descend through to-one segments and map over to-many (list) segments at any position, joining the collected values. This handles any mix of to-one/to-many relations.

Single-level to-many columns (e.g. `comments.body`) and plain to-one columns (e.g. `user.name`) are unaffected. Tests cover all three shapes.