### PR TITLE
Show shared filters to everyone, not just users who can share

### DIFF
--- a/src/Traits/DataTables/StoresSettings.php
+++ b/src/Traits/DataTables/StoresSettings.php
@@ -98,12 +98,13 @@ trait StoresSettings
                         ->where('authenticatable_type', $user->getMorphClass());
                 });
 
-                if ($this->canShareFilters()) {
-                    $q->orWhere(function ($shared) use ($user): void {
-                        $shared->where('is_shared', true)
-                            ->where('authenticatable_type', $user->getMorphClass());
-                    });
-                }
+                // Shared filters are visible to everyone who can see the table. The
+                // canShareFilters() permission only governs *creating* a shared filter
+                // (see compileLayoutSettings / the allowed fields), not viewing one.
+                $q->orWhere(function ($shared) use ($user): void {
+                    $shared->where('is_shared', true)
+                        ->where('authenticatable_type', $user->getMorphClass());
+                });
             });
 
         if ($filter) {

--- a/tests/Feature/SharedFiltersTest.php
+++ b/tests/Feature/SharedFiltersTest.php
@@ -89,7 +89,9 @@ describe('Shared Saved Filters', function (): void {
             expect($names)->not->toContain('Private Other');
         });
 
-        it('does not include shared filters when gate is false', function (): void {
+        it('includes shared filters from other users even when the share gate is false', function (): void {
+            // Seeing shared filters must not require the share permission; that gate
+            // only governs creating/sharing a filter, not viewing one.
             DatatableUserSetting::create([
                 'name' => 'Shared By Other',
                 'component' => PostDataTable::class,
@@ -104,7 +106,7 @@ describe('Shared Saved Filters', function (): void {
 
             $component = Livewire::test(PostDataTable::class);
             $names = collect($component->get('savedFilters'))->pluck('name')->toArray();
-            expect($names)->not->toContain('Shared By Other');
+            expect($names)->toContain('Shared By Other');
         });
     });
 


### PR DESCRIPTION
## Problem

`getSavedFilters()` only loaded shared filters when `canShareFilters()` returned true. That ties **viewing** shared filters to the **share permission**: a user without it cannot see filters another user explicitly shared for everyone — which defeats the purpose of sharing.

## Change

Always load shared filters (`is_shared = true`) for any user who can see the table. The `canShareFilters()` gate continues to govern only the *creation* side — marking a filter as shared (`compileLayoutSettings` / allowed fields / the share toggle) is unchanged.

## Test

Updated the loading test: a shared filter from another user is now visible even when the share gate is false. Full shared-filters suite passes (15).