### PR TITLE
Qualify capped to-many relation select columns and surface query errors

### DIFF
--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -213,7 +213,11 @@ trait BuildsQueries
 
             $query->with([$path => function ($relationQuery) use ($select, $cap): void {
                 if ($select) {
-                    $relationQuery->select($select);
+                    $table = $relationQuery->getModel()->getTable();
+                    $relationQuery->select(array_map(
+                        fn (string $column): string => str_contains($column, '.') ? $column : $table . '.' . $column,
+                        $select
+                    ));
                 }
 
                 $relationQuery->limit($cap);
@@ -481,7 +485,7 @@ trait BuildsQueries
                 );
             }
         } catch (QueryException $e) {
-            $this->toast()->error($e->getMessage());
+            $this->toast()->error($e->getMessage())->send();
 
             return [];
         }

--- a/src/Traits/DataTables/SupportsAggregation.php
+++ b/src/Traits/DataTables/SupportsAggregation.php
@@ -94,7 +94,7 @@ trait SupportsAggregation
                         : $this->modelTable . '.' . $column;
                     $aggregates[$type][$column] = $builder->{$type}($qualifiedColumn);
                 } catch (QueryException $e) {
-                    $this->toast()->error($e->getMessage());
+                    $this->toast()->error($e->getMessage())->send();
 
                     continue;
                 }

--- a/tests/Feature/RelationColumnSelectQualifiedTest.php
+++ b/tests/Feature/RelationColumnSelectQualifiedTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Livewire\Livewire;
+use Tests\Fixtures\Livewire\PostWithTagsDataTable;
+use Tests\Fixtures\Models\Tag;
+
+beforeEach(function (): void {
+    $this->user = createTestUser();
+    $this->actingAs($this->user);
+});
+
+it('qualifies capped to-many select columns so pivot joins do not throw ambiguous column errors', function (): void {
+    config(['tall-datatables.max_relation_column_values' => 50]);
+
+    $post = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Tagged']);
+    $post->tags()->attach(Tag::create(['name' => 'Laravel'])->getKey());
+    $post->tags()->attach(Tag::create(['name' => 'Livewire'])->getKey());
+
+    $data = Livewire::test(PostWithTagsDataTable::class)->instance()->getDataForTesting();
+
+    $cell = $data['data'][0]['tags.name'] ?? [];
+    $values = is_array($cell) && array_key_exists('raw', $cell) ? $cell['raw'] : $cell;
+
+    expect($values)->toContain('Laravel', 'Livewire');
+});

--- a/tests/Fixtures/Livewire/PostWithTagsDataTable.php
+++ b/tests/Fixtures/Livewire/PostWithTagsDataTable.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Fixtures\Livewire;
+
+use TeamNiftyGmbH\DataTable\DataTable;
+use Tests\Fixtures\Models\Post;
+
+class PostWithTagsDataTable extends DataTable
+{
+    public array $availableRelations = [
+        'tags',
+    ];
+
+    public array $enabledCols = [
+        'title',
+        'tags.name',
+    ];
+
+    protected string $model = Post::class;
+}

--- a/tests/database/migrations/0001_01_01_000004_create_tags_table.php
+++ b/tests/database/migrations/0001_01_01_000004_create_tags_table.php
@@ -15,6 +15,7 @@ return new class() extends Migration
         });
 
         Schema::create('taggables', function (Blueprint $table): void {
+            $table->id();
             $table->foreignId('tag_id')->constrained()->cascadeOnDelete();
             $table->morphs('taggable');
         });


### PR DESCRIPTION
## Problem

The relation-column cap introduced in #254 selects unqualified columns inside the eager-load closure:

```php
$relationQuery->select($select); // e.g. ['id', 'name']
```

On `BelongsToMany` / `MorphToMany` relations the pivot join makes a bare column such as `id` ambiguous, so Eloquent throws an **integrity constraint violation** for *any* such relation. This broke contacts/addresses/finance-advice tables on VVO dev (the `owners` relation), while other environments happened to select non-colliding columns.

On top of that, the `QueryException` handlers queued a toast but never called `->send()`, so the failure was swallowed silently and the table just rendered empty — no error surfaced to the user.

## Fix

- Qualify each dotless select column with the related table name, matching the pattern already used for aggregation columns in `SupportsAggregation`.
- Call `->send()` on both `QueryException` toasts so the error is actually shown.

## Test

`RelationColumnSelectQualifiedTest` reproduces the ambiguity via a `MorphToMany` pivot carrying its own `id`. It fails without the fix (ambiguous column → empty result) and passes with it.