### PR TITLE
Qualify only BelongsToMany relation select columns

### DIFF
--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -213,11 +213,13 @@ trait BuildsQueries
 
             $query->with([$path => function ($relationQuery) use ($select, $cap): void {
                 if ($select) {
-                    $table = $relationQuery->getModel()->getTable();
-                    $relationQuery->select(array_map(
-                        fn (string $column): string => str_contains($column, '.') ? $column : $table . '.' . $column,
-                        $select
-                    ));
+                    // Only BelongsToMany joins a pivot table, so a bare column like `id`
+                    // becomes ambiguous there — qualify it exactly like Laravel does.
+                    $relationQuery->select(
+                        $relationQuery instanceof BelongsToMany
+                            ? $relationQuery->getRelated()->qualifyColumns($select)
+                            : $select
+                    );
                 }
 
                 $relationQuery->limit($cap);


### PR DESCRIPTION
## Context

Follow-up to #257. That fix qualified the capped select columns of **every** to-many relation via a per-column `array_map` + `str_contains`. Only `BelongsToMany` joins a pivot table, so only there can a bare column such as `id` become ambiguous. `HasMany` and its siblings never needed qualification and paid the overhead for nothing — which made the tables feel less performant.

## Fix

Narrow qualification to `BelongsToMany` and reuse Laravel's own `qualifyColumns()`, exactly how the framework resolves this internally:

```php
$relationQuery->select(
    $relationQuery instanceof BelongsToMany
        ? $relationQuery->getRelated()->qualifyColumns($select)
        : $select
);
```

`MorphToMany` extends `BelongsToMany`, so it stays covered. The existing `RelationColumnSelectQualifiedTest` (MorphToMany pivot with its own `id`) still passes.

Credit to @SirSplasch for pointing at Laravel's internal approach.