### PR TITLE
Show text-filter-only saved filters in head quick-select

### DIFF
--- a/resources/views/components/head.blade.php
+++ b/resources/views/components/head.blade.php
@@ -9,15 +9,14 @@
 @endif
 
 <div class="flex w-full justify-end gap-2">
-    @if (count($this->savedFilters) > 0 && $this->showSavedFilters)
+    @if (count($this->quickSelectSavedFilters()) > 0 && $this->showSavedFilters)
         <div>
             <x-select.styled
                 x-on:select="$wire.loadSavedFilter()"
                 wire:model="loadedFilterId"
                 select="label:label|value:value"
                 :placeholder="__('Saved filters')"
-                :options="collect($this->savedFilters)
-                    ->filter(fn(array $savedFilter) => data_get($savedFilter, 'settings.userFilters', false))
+                :options="collect($this->quickSelectSavedFilters())
                     ->map(function(array $savedFilter) {
                         return [
                             'label' => $savedFilter['name'],

--- a/src/Traits/DataTables/StoresSettings.php
+++ b/src/Traits/DataTables/StoresSettings.php
@@ -184,6 +184,22 @@ trait StoresSettings
         $this->colLabels = $this->getColLabels();
     }
 
+    /**
+     * Saved filters that carry actual filter criteria (userFilters or textFilters).
+     * Used for the quick-select in the table head; layout/column-only saves are excluded.
+     *
+     * @return array<int, array>
+     */
+    #[Renderless]
+    public function quickSelectSavedFilters(): array
+    {
+        return collect($this->savedFilters)
+            ->filter(fn (array $savedFilter): bool => filled(data_get($savedFilter, 'settings.userFilters'))
+                || filled(data_get($savedFilter, 'settings.textFilters')))
+            ->values()
+            ->all();
+    }
+
     public function resetLayout(): void
     {
         try {

--- a/tests/Feature/StoresSettingsTest.php
+++ b/tests/Feature/StoresSettingsTest.php
@@ -1363,3 +1363,30 @@ describe('mountStoresSettings with session cache', function (): void {
             ->and($component->get('userOrderAsc'))->toBeFalse();
     });
 });
+
+describe('quickSelectSavedFilters', function (): void {
+    it('includes filters with userFilters or textFilters and excludes layout-only saves', function (): void {
+        $component = Livewire::test(PostDataTable::class);
+
+        $component->set('savedFilters', [
+            ['id' => 1, 'name' => 'UserFilter', 'settings' => [
+                'userFilters' => [[['column' => 'title', 'operator' => 'like', 'value' => '%a%', 'source' => 'text']]],
+                'textFilters' => [],
+            ]],
+            ['id' => 2, 'name' => 'TextOnly', 'settings' => [
+                'userFilters' => [],
+                'textFilters' => [['column' => 'title', 'value' => 'x']],
+            ]],
+            ['id' => 3, 'name' => 'LayoutOnly', 'settings' => [
+                'userFilters' => [],
+                'textFilters' => [],
+            ]],
+        ]);
+
+        $names = array_column($component->instance()->quickSelectSavedFilters(), 'name');
+
+        expect($names)->toContain('UserFilter')
+            ->toContain('TextOnly')
+            ->not->toContain('LayoutOnly');
+    });
+});


### PR DESCRIPTION
## Problem

The saved-filters quick-select in the table head only listed saved filters whose `settings.userFilters` was non-empty:

```php
->filter(fn(array $savedFilter) => data_get($savedFilter, 'settings.userFilters', false))
```

A filter built purely from the column `textFilters` (the per-column header inputs) has an empty `userFilters` array, so it was hidden from the quick-select even though it exists and applies real criteria. Users reported saving a filter and not finding it in the "Saved filters" field, while it was still present in the options-panel list.

## Change

- Add `quickSelectSavedFilters()` to `StoresSettings`: returns saved filters carrying either `userFilters` **or** `textFilters`.
- `head.blade.php` uses it for both the render guard and the option list.
- Layout/column-only saves (no filter criteria at all) remain excluded, which is the intended behavior for the quick-select.

## Tests

New `quickSelectSavedFilters` test covers all three cases (userFilters-only, textFilters-only, layout-only). Full suite green, Pint clean.