### PR TITLE
Export boolean relation columns as text

### DIFF
--- a/src/Exports/Concerns/ExportsData.php
+++ b/src/Exports/Concerns/ExportsData.php
@@ -3,7 +3,9 @@
 namespace TeamNiftyGmbH\DataTable\Exports\Concerns;
 
 use Illuminate\Support\Str;
+use TeamNiftyGmbH\DataTable\Formatters\ArrayFormatter;
 use TeamNiftyGmbH\DataTable\Formatters\BooleanFormatter;
+use TeamNiftyGmbH\DataTable\Formatters\Contracts\Formatter;
 
 trait ExportsData
 {
@@ -35,26 +37,32 @@ trait ExportsData
 
         foreach ($this->exportColumns as $column) {
             $value = data_get($rowArray, $column);
+            $formatter = $this->exportFormatters[$column] ?? null;
 
             if (is_null($value) && str_contains($column, '.')) {
                 $value = $this->extractNestedValue($rowArray, explode('.', $column));
 
                 if (is_array($value)) {
+                    // Format every related value on its own, otherwise an element formatter
+                    // (e.g. a boolean rendered as an icon) never sees the individual values.
                     $value = implode('; ', array_filter(
-                        $value,
+                        array_map(
+                            fn ($item) => $this->formatExportValue($item, $formatter, $rowArray),
+                            $value
+                        ),
                         fn ($item) => $item !== null && $item !== ''
                     ));
+
+                    $result[$column] = $value;
+
+                    continue;
                 }
             }
 
-            if (! is_null($value) && isset($this->exportFormatters[$column])) {
-                $formatter = $this->exportFormatters[$column];
-
-                if ($formatter instanceof BooleanFormatter) {
-                    $value = $value ? __('Yes') : __('No');
-                } else {
-                    $value = strip_tags($formatter->format($value, $rowArray));
-                }
+            if (! is_null($value) && $formatter) {
+                $value = is_array($value)
+                    ? strip_tags($formatter->format($value, $rowArray))
+                    : $this->formatExportValue($value, $formatter, $rowArray);
             }
 
             $result[$column] = $value;
@@ -95,5 +103,27 @@ trait ExportsData
         $segment = array_shift($segments);
 
         return $this->extractNestedValue(data_get($data, $segment), $segments);
+    }
+
+    /**
+     * Format a single scalar value for the export, unwrapping array formatters so their
+     * element formatter decides. Boolean values are exported as text because their
+     * formatter renders an icon, which strip_tags would reduce to an empty cell.
+     */
+    protected function formatExportValue(mixed $value, ?Formatter $formatter, array $context): mixed
+    {
+        if (is_null($value) || is_null($formatter)) {
+            return $value;
+        }
+
+        if ($formatter instanceof ArrayFormatter) {
+            $formatter = $formatter->elementFormatter() ?? $formatter;
+        }
+
+        if ($formatter instanceof BooleanFormatter) {
+            return $value ? __('Yes') : __('No');
+        }
+
+        return strip_tags($formatter->format($value, $context));
     }
 }

--- a/src/Formatters/ArrayFormatter.php
+++ b/src/Formatters/ArrayFormatter.php
@@ -10,6 +10,11 @@ class ArrayFormatter implements Formatter
         protected ?Formatter $elementFormatter = null,
     ) {}
 
+    public function elementFormatter(): ?Formatter
+    {
+        return $this->elementFormatter;
+    }
+
     public function format(mixed $value, array $context = []): string
     {
         if (is_null($value)) {

--- a/tests/Feature/ExportNestedRelationTest.php
+++ b/tests/Feature/ExportNestedRelationTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use TeamNiftyGmbH\DataTable\Exports\DataTableExport;
+use TeamNiftyGmbH\DataTable\Formatters\ArrayFormatter;
+use TeamNiftyGmbH\DataTable\Formatters\BooleanFormatter;
 use Tests\Fixtures\Models\Post;
 
 beforeEach(function (): void {
@@ -35,6 +37,38 @@ it('still exports a single-level to-many relation column', function (): void {
     $row = $export->mapRow($post);
 
     expect($row['comments.body'])->toContain('First')->toContain('Second');
+});
+
+it('exports boolean values of a to-many relation column as text', function (): void {
+    $post = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Flags']);
+    createTestComment(['post_id' => $post->getKey(), 'user_id' => $this->user->getKey(), 'is_approved' => true]);
+    createTestComment(['post_id' => $post->getKey(), 'user_id' => $this->user->getKey(), 'is_approved' => false]);
+
+    $post = Post::query()->with('comments')->find($post->getKey());
+
+    $export = new DataTableExport(
+        Post::query(),
+        ['comments.is_approved'],
+        ['comments.is_approved' => new ArrayFormatter(elementFormatter: new BooleanFormatter())],
+    );
+    $row = $export->mapRow($post);
+
+    expect($row['comments.is_approved'])->toBe(__('Yes') . '; ' . __('No'));
+});
+
+it('exports a boolean column of a to-one relation as text', function (): void {
+    $post = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Published', 'is_published' => true]);
+    $comment = createTestComment(['post_id' => $post->getKey(), 'user_id' => $this->user->getKey()]);
+    $comment = $comment->load('post');
+
+    $export = new DataTableExport(
+        Post::query(),
+        ['post.is_published'],
+        ['post.is_published' => new BooleanFormatter()],
+    );
+    $row = $export->mapRow($comment);
+
+    expect($row['post.is_published'])->toBe(__('Yes'));
 });
 
 it('exports a plain to-one relation column unchanged', function (): void {

--- a/tests/Fixtures/Models/Comment.php
+++ b/tests/Fixtures/Models/Comment.php
@@ -9,6 +9,13 @@ class Comment extends Model
 {
     protected $guarded = ['id'];
 
+    protected function casts(): array
+    {
+        return [
+            'is_approved' => 'boolean',
+        ];
+    }
+
     public function post(): BelongsTo
     {
         return $this->belongsTo(Post::class);

--- a/tests/database/migrations/0001_01_01_000002_create_comments_table.php
+++ b/tests/database/migrations/0001_01_01_000002_create_comments_table.php
@@ -13,6 +13,7 @@ return new class() extends Migration
             $table->foreignId('post_id')->constrained()->cascadeOnDelete();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->text('body');
+            $table->boolean('is_approved')->default(false);
             $table->timestamps();
         });
     }


### PR DESCRIPTION
## Problem

Exporting a boolean column that sits behind a relation produces an empty cell whenever formatted values are enabled (the default in the export tab).

`constructWith()` resolves such a column to an `ArrayFormatter` wrapping a `BooleanFormatter`. In `mapRow()` the related values were imploded into a single string *before* formatting, so the `instanceof BooleanFormatter` special case never matched. The value fell through to the else branch, where the wrapped `BooleanFormatter` renders an SVG icon and `strip_tags()` reduced the cell to an empty string.

A `false` value was silently dropped as well, because the pre-implode `array_filter` removed it.

## Fix

- Format every related value on its own before imploding, so an element formatter sees the individual values.
- Unwrap `ArrayFormatter` to its element formatter when formatting a scalar.
- Export booleans as `Yes`/`No` in both the to-one and the to-many case; `false` now exports as `No` instead of vanishing.

## Tests

`tests/Feature/ExportNestedRelationTest.php` gains coverage for a boolean column of a to-many relation and of a to-one relation. The comments fixture gets an `is_approved` boolean for that. The new to-many test fails on `main` with `'' !== 'Yes; No'`.