### PR TITLE
Make Reset Layout reach the sidebar again

### DIFF
--- a/dist/build/manifest.json
+++ b/dist/build/manifest.json
@@ -9,7 +9,7 @@
     "isEntry": true
   },
   "resources/js/tall-datatables.js": {
-    "file": "assets/tall-datatables-CuHzzV6d.js",
+    "file": "assets/tall-datatables-C8F7rmW4.js",
     "name": "tall-datatables",
     "src": "resources/js/tall-datatables.js",
     "isEntry": true

--- a/resources/js/components/datatable-options.js
+++ b/resources/js/components/datatable-options.js
@@ -25,6 +25,7 @@ export default function datatable_options(wire) {
             start_of: null,
         },
         enabledCols: wire.enabledCols || [],
+        availableCols: [...(wire.enabledCols || []), '__placeholder__'],
         filterValueLists: wire.filterValueLists || {},
         groupBy: wire.groupBy || null,
         orderByCol: wire.userOrderBy || '',
@@ -376,10 +377,26 @@ export default function datatable_options(wire) {
             wire.storeColLayout(cols);
         },
 
+        addCol(colName) {
+            if (this.availableCols.includes(colName))
+                this.availableCols.splice(
+                    this.availableCols.indexOf(colName),
+                    1,
+                );
+            else {
+                this.availableCols.push(colName);
+            }
+        },
+
+        syncAvailableCols() {
+            this.availableCols = [...this.enabledCols, '__placeholder__'];
+        },
+
         resetLayout() {
             this._ready = false;
             wire.resetLayout().then(() => {
                 this.enabledCols = wire.enabledCols || [];
+                this.syncAvailableCols();
                 this._sidebarLoaded = false;
                 this.loadSidebarData();
                 this.$nextTick(() => {
@@ -435,6 +452,7 @@ export default function datatable_options(wire) {
 
         async init() {
             this.enabledCols = wire.enabledCols || [];
+            this.syncAvailableCols();
             this.filterValueLists =
                 wire.filterValueLists || {};
             this.groupBy = wire.groupBy || null;

--- a/resources/views/components/options/tabs/columns.blade.php
+++ b/resources/views/components/options/tabs/columns.blade.php
@@ -1,16 +1,4 @@
-<div
-    x-data="{
-        attributes: [],
-        availableCols: [...wire.enabledCols, ...['__placeholder__']],
-        addCol(colName) {
-            if (this.availableCols.includes(colName))
-                this.availableCols.splice(this.availableCols.indexOf(colName), 1)
-            else {
-                this.availableCols.push(colName)
-            }
-        },
-    }"
->
+<div x-data="{ attributes: [] }">
     <div class="border-b border-gray-200 pb-2 dark:border-secondary-700">
     <div
         class="table-cols"
@@ -55,7 +43,7 @@
             color="secondary"
             light
             loading="resetLayout"
-            x-on:click="$wire.resetLayout()"
+            x-on:click="resetLayout()"
             :text="__('Reset Layout')"
         />
         @if($this->canSaveDefaultColumns())

--- a/tests/Browser/ResetLayoutBrowserTest.php
+++ b/tests/Browser/ResetLayoutBrowserTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Browser Tests for Reset Layout
+ *
+ * The reset only shows up in a real browser: the server side of resetLayout()
+ * has always worked, what broke was the sidebar keeping its own copy of the
+ * columns and never picking the reset ones up.
+ */
+
+use Tests\Fixtures\Livewire\DefaultColumnsPostDataTable;
+
+beforeEach(function (): void {
+    $manifestPath = dirname(__DIR__, 2) . '/dist/build/manifest.json';
+    if (! file_exists($manifestPath)) {
+        $this->markTestSkipped('Browser tests require built assets. Run: npm run build');
+    }
+
+    $this->user = createTestUser(['name' => 'Test User', 'email' => 'reset-layout@example.com']);
+
+    createTestPost([
+        'user_id' => $this->user->getKey(),
+        'title' => 'Post Title 1',
+        'content' => 'Content 1',
+        'is_published' => true,
+    ]);
+});
+
+describe('Reset layout', function (): void {
+    it('pulls the reset columns back into the sidebar', function (): void {
+        $page = visitLivewire(DefaultColumnsPostDataTable::class);
+
+        $page->wait(2);
+
+        $result = $page->script('async () => {
+            const el = document.querySelector(\'[x-data^="datatableOptions"]\');
+
+            if (! el) {
+                return "no-options-component";
+            }
+
+            const options = window.Alpine.$data(el);
+            const before = [...options.enabledCols];
+
+            options.enabledCols = [before[0]];
+            options.syncAvailableCols();
+
+            await options.resetLayout();
+            await new Promise((resolve) => setTimeout(resolve, 1500));
+
+            return JSON.stringify({
+                enabledCols: options.enabledCols,
+                availableCols: options.availableCols,
+                before,
+            });
+        }');
+
+        $raw = is_array($result) && isset($result[0]) ? $result[0] : $result;
+
+        expect($raw)->not->toBe('no-options-component');
+
+        $state = json_decode((string) $raw, true);
+
+        expect($state['enabledCols'])->toBe($state['before'])
+            ->and($state['availableCols'])->toBe([...$state['before'], '__placeholder__']);
+    });
+});

--- a/tests/Feature/DefaultColumnsTest.php
+++ b/tests/Feature/DefaultColumnsTest.php
@@ -37,10 +37,14 @@ describe('Global Default Columns', function (): void {
                 ->and($html)->not->toContain('wire:click="saveDefaultColumns"');
         });
 
-        it('renders Reset Layout button with $wire-prefixed method call (Livewire v4)', function (): void {
+        it('renders Reset Layout button calling the alpine wrapper, not $wire directly', function (): void {
             $html = Livewire::test(DefaultColumnsPostDataTable::class)->html();
 
-            expect($html)->toContain('x-on:click="$wire.resetLayout()"')
+            // The alpine wrapper awaits $wire.resetLayout() and then pulls the
+            // reset columns back into the sidebar. Calling $wire directly leaves
+            // the sidebar on the columns from before the reset.
+            expect($html)->toContain('x-on:click="resetLayout()"')
+                ->and($html)->not->toContain('x-on:click="$wire.resetLayout()"')
                 ->and($html)->not->toContain('x-on:click="resetLayout"');
         });
 


### PR DESCRIPTION
## Problem

The **Reset Layout** button in the columns tab does nothing visible. The table keeps the layout it had.

The server side has always worked — `StoresSettings::resetLayout()` deletes the stored layout, clears the session cache and reloads the data. What it cannot do is reach the sidebar, because the options component keeps its own copy of the columns in Alpine.

There is an Alpine wrapper `resetLayout()` in `datatable-options.js` that exists for precisely this: it awaits the round trip and then pulls the reset columns back in. The button skipped it and called `$wire.resetLayout()` directly, so the sidebar kept the columns from before the reset — and the next interaction wrote them straight back through `storeColLayout()`.

The sortable column list had the same problem one level deeper. `availableCols` lived in a nested `x-data` in the blade and was seeded from `wire.enabledCols` exactly once, so a reset could neither bring a default column back into the list nor drop one that had been added.

## Change

- Point the button at the Alpine wrapper instead of `$wire`.
- Move `availableCols` and `addCol` out of the nested `x-data` into the options component, so the wrapper can resync them alongside `enabledCols`.

## Tests

`DefaultColumnsTest` asserted the `$wire.` form, i.e. it pinned the bug in place. It now asserts the wrapper form and still rejects the bare `x-on:click="resetLayout"` that the earlier Livewire v4 fix removed.

A browser test covers the actual reset, since neither half of this shows up outside a real browser.