### PR TITLE
Qualify relation select columns with their related table

### DIFF
--- a/src/Helpers/SchemaInfo.php
+++ b/src/Helpers/SchemaInfo.php
@@ -18,6 +18,12 @@ use UnitEnum;
 
 class SchemaInfo
 {
+    /**
+     * Bump the suffix whenever the cached "with" payload changes, so an upgrade
+     * does not keep serving entries built by an older version of the package.
+     */
+    public const WITH_CACHE_KEY_SUFFIX = '.with.v2';
+
     /** @var array<string, static> */
     protected static array $cache = [];
 
@@ -37,6 +43,8 @@ class SchemaInfo
         $cacheKey = config('tall-datatables.cache_key');
         Cache::forget($cacheKey . '.modelInfo');
         Cache::forget($cacheKey . '.modelFinder');
+        Cache::forget($cacheKey . static::WITH_CACHE_KEY_SUFFIX);
+        // drop the pre-v2 bucket as well so upgrades leave nothing behind
         Cache::forget($cacheKey . '.with');
     }
 

--- a/src/Traits/DataTables/SupportsRelations.php
+++ b/src/Traits/DataTables/SupportsRelations.php
@@ -249,7 +249,7 @@ trait SupportsRelations
     {
         // cache key for the enabled cols
         $cacheKey = md5(json_encode($this->enabledCols) . $this->getCacheKey());
-        $withCacheKey = config('tall-datatables.cache_key') . '.with';
+        $withCacheKey = config('tall-datatables.cache_key') . SchemaInfo::WITH_CACHE_KEY_SUFFIX;
         $cached = Cache::get($withCacheKey);
 
         // Clear stale cache from pre-SchemaInfo era that may contain unserializable objects
@@ -316,6 +316,7 @@ trait SupportsRelations
 
         $modelBase = app($this->getModel());
         $with = ['__root__' => []];
+        $relationTables = [];
         $modelInfos = [];
         $filterable = [];
         $sortable = [];
@@ -366,6 +367,11 @@ trait SupportsRelations
                     $model = $relationInstance->getRelated();
                 } catch (Throwable) {
                     $model = null;
+                }
+
+                // a MorphTo resolves to several related tables, so its columns must stay unqualified
+                if ($model && ! $relationInstance instanceof MorphTo) {
+                    $relationTables[$path] = $model->getTable();
                 }
 
                 if ($relationInstance instanceof BelongsTo) {
@@ -450,7 +456,16 @@ trait SupportsRelations
         $select = Arr::pull($with, '__root__');
         $select = array_map(fn ($field) => $modelBase->getTable() . '.' . $field, $select);
         foreach ($with as $name => $item) {
-            $with[$name] = $name . ':' . implode(',', array_values(array_unique($item)));
+            $columns = array_values(array_unique($item));
+            $table = $relationTables[$name] ?? null;
+
+            // relations that join (through, pivot) select from more than one table,
+            // so an unqualified column like "id" would be ambiguous
+            if ($table && $columns !== ['*']) {
+                $columns = array_map(fn ($field) => $table . '.' . $field, $columns);
+            }
+
+            $with[$name] = $name . ':' . implode(',', $columns);
         }
 
         $returnValue = [
@@ -464,7 +479,7 @@ trait SupportsRelations
         ];
 
         Cache::put(
-            config('tall-datatables.cache_key') . '.with',
+            $withCacheKey,
             array_merge($cached ?? [], [$cacheKey => $returnValue])
         );
 

--- a/tests/Feature/RelationColumnThroughSelectTest.php
+++ b/tests/Feature/RelationColumnThroughSelectTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Livewire\Livewire;
+use Tests\Fixtures\Livewire\CommentWithPostUserDataTable;
+use Tests\Fixtures\Livewire\PostWithCommentsDataTable;
+
+beforeEach(function (): void {
+    $this->user = createTestUser();
+    $this->actingAs($this->user);
+});
+
+it('qualifies through relation select columns so the through join does not throw ambiguous column errors', function (): void {
+    $instance = Livewire::test(CommentWithPostUserDataTable::class)->instance();
+
+    $constructWith = new ReflectionMethod($instance, 'constructWith');
+    $constructWith->setAccessible(true);
+
+    expect($constructWith->invoke($instance)[0])->toContain('postUser:users.id,users.name');
+});
+
+it('qualifies relation select columns for plain relations as well', function (): void {
+    $instance = Livewire::test(PostWithCommentsDataTable::class)->instance();
+
+    $constructWith = new ReflectionMethod($instance, 'constructWith');
+    $constructWith->setAccessible(true);
+
+    expect($constructWith->invoke($instance)[0])->toContain('comments:comments.post_id,comments.body');
+});

--- a/tests/Fixtures/Livewire/CommentWithPostUserDataTable.php
+++ b/tests/Fixtures/Livewire/CommentWithPostUserDataTable.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Fixtures\Livewire;
+
+use TeamNiftyGmbH\DataTable\DataTable;
+use Tests\Fixtures\Models\Comment;
+
+class CommentWithPostUserDataTable extends DataTable
+{
+    public array $enabledCols = [
+        'body',
+        'post_user.name',
+    ];
+
+    protected string $model = Comment::class;
+}

--- a/tests/Fixtures/Models/Comment.php
+++ b/tests/Fixtures/Models/Comment.php
@@ -4,6 +4,7 @@ namespace Tests\Fixtures\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 
 class Comment extends Model
 {
@@ -19,6 +20,18 @@ class Comment extends Model
     public function post(): BelongsTo
     {
         return $this->belongsTo(Post::class);
+    }
+
+    public function postUser(): HasOneThrough
+    {
+        return $this->hasOneThrough(
+            User::class,
+            Post::class,
+            'id',
+            'id',
+            'post_id',
+            'user_id'
+        );
     }
 
     public function user(): BelongsTo


### PR DESCRIPTION
## Problem

Eager loading a relation with an explicit column list produced an unqualified select:

```
postUser:id,name
```

For relations that join — `HasOneThrough`, `HasManyThrough`, or a pivot table that carries an `id` column — the join pulls a second table into the same select, so a bare `id` is ambiguous and the query fails:

```
SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'id' in field list is ambiguous
SQL: select `id`, `name`, `contacts`.`id` as `laravel_through_key` from `price_lists`
     inner join `contacts` on `contacts`.`price_list_id` = `price_lists`.`id`
```

The root model's select was already qualified; the relation selects were not.

## Change

- Track the related table per relation path while walking the enabled columns, then prefix the selected columns with it.
- `MorphTo` resolves to several related tables, so its columns stay unqualified.
- A `['*']` select is left untouched.

## Cache

The constructed `with` payload is cached without a TTL, so an existing installation would keep serving entries built before this fix. The cache bucket is bumped to `.with.v2` and `SchemaInfo::flush()` now drops both the current and the pre-v2 bucket.

## Tests

`tests/Feature/RelationColumnThroughSelectTest.php` covers a `HasOneThrough` relation (new `Comment::postUser()` fixture) and a plain `HasMany`. Both fail without the change.

Unit + Feature suite: 2095 passed, 1 skipped.