### PR TITLE
Make sticky columns apply to body cells without a re-render

### DIFF
--- a/resources/views/components/layouts/partials/table-groups.blade.php
+++ b/resources/views/components/layouts/partials/table-groups.blade.php
@@ -82,10 +82,12 @@
                     ></td>
                 @endif
                 @foreach ($enabledCols as $col)
+                    {{-- bound through Alpine like the head and filter cells, so toggling a sticky column takes effect without a re-render --}}
                     <x-tall-datatables::table.cell
                         :use-wire-navigate="$useWireNavigate"
-                        :class="in_array($col, $this->stickyCols) ? 'sticky left-0 border-r bg-white dark:bg-secondary-800 dark:text-gray-50' : ''"
-                        :style="in_array($col, $this->stickyCols) ? 'z-index: 2' : ''"
+                        :data-column="$col"
+                        x-bind:class="($wire.stickyCols || []).includes({{ \Illuminate\Support\Js::from($col) }}) ? 'sticky left-0 border-r bg-white dark:bg-secondary-800 dark:text-gray-50' : ''"
+                        x-bind:style="($wire.stickyCols || []).includes({{ \Illuminate\Support\Js::from($col) }}) ? 'z-index: 2' : ''"
                         :href="(($allowSoftDeletes && ($record['deleted_at'] ?? null)) ? null : ($record['href'] ?? null))"
                     >
                         @if (is_array($record[$col] ?? null) && isset($record[$col]['display']))

--- a/resources/views/components/layouts/partials/table-row.blade.php
+++ b/resources/views/components/layouts/partials/table-row.blade.php
@@ -55,10 +55,13 @@
                 . (preg_match("/^'([^']*)'$/", $cellAttributes->get('x-bind:class', ''), $m) ? $m[1] : '')
             );
         @endphp
+        {{-- bound through Alpine like the head and filter cells, so toggling a sticky column takes effect without a re-render --}}
         <x-tall-datatables::table.cell
             :use-wire-navigate="$useWireNavigate"
-            :class="implode(' ', array_filter([in_array($col, $this->stickyCols) ? 'sticky left-0 border-r bg-white dark:bg-secondary-800 dark:text-gray-50' : '', $cellAttrClasses]))"
-            :style="in_array($col, $this->stickyCols) ? 'z-index: 2' : ''"
+            :data-column="$col"
+            :class="$cellAttrClasses"
+            x-bind:class="($wire.stickyCols || []).includes({{ \Illuminate\Support\Js::from($col) }}) ? 'sticky left-0 border-r bg-white dark:bg-secondary-800 dark:text-gray-50' : ''"
+            x-bind:style="($wire.stickyCols || []).includes({{ \Illuminate\Support\Js::from($col) }}) ? 'z-index: 2' : ''"
             :href="(($allowSoftDeletes && ($record['deleted_at'] ?? null)) ? null : ($record['href'] ?? null))"
         >
             @php

--- a/resources/views/components/table/cell.blade.php
+++ b/resources/views/components/table/cell.blade.php
@@ -13,7 +13,7 @@
     }
 @endphp
 <td
-    {{ $attributes->only(['class', 'x-bind:class', 'x-bind:style'])->merge(['class' => $defaultClasses]) }}
+    {{ $attributes->only(['class', 'x-bind:class', 'x-bind:style', 'data-column'])->merge(['class' => $defaultClasses]) }}
 >
     @if($hasStaticHref)
         <a

--- a/tests/Feature/StickyColsBodyCellTest.php
+++ b/tests/Feature/StickyColsBodyCellTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Livewire\Livewire;
+use Tests\Fixtures\Livewire\PostDataTable;
+
+beforeEach(function (): void {
+    $this->user = createTestUser();
+    $this->actingAs($this->user);
+});
+
+it('binds the sticky class of body cells to stickyCols so no re-render is needed', function (): void {
+    createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Sticky Row']);
+
+    $html = Livewire::test(PostDataTable::class)->call('loadData')->html();
+
+    preg_match('/<td[^>]*data-column="title"[^>]*>/', $html, $matches);
+
+    expect($matches[0] ?? '')
+        ->toContain('x-bind:class="($wire.stickyCols || []).includes(\'title\') ? \'sticky left-0 border-r')
+        ->toContain('x-bind:style="($wire.stickyCols || []).includes(\'title\') ? \'z-index: 2\' : \'\'"');
+});


### PR DESCRIPTION
## Problem

Marking a column sticky only moved the head cell. The body cells stayed where they were until something caused a re-render, at which point they jumped into place.

The head cell and the filter row bind their sticky classes through Alpine:

```blade
x-bind:class="($wire.stickyCols || []).includes(col) ? 'left-0 z-10 border-r' : ''"
```

The body cells computed the same classes server side:

```blade
:class="in_array($col, $this->stickyCols) ? 'sticky left-0 border-r ...' : ''"
```

Toggling `stickyCols` does not re-render those rows, so the body kept the classes from the previous render.

## Change

- Body cells bind their sticky class and z-index through Alpine, matching the head and filter cells.
- The column name is exposed as `data-column` so the cell can be targeted.
- The grouped rows partial carried the same server side logic and is fixed as well.

## Tests

`tests/Feature/StickyColsBodyCellTest.php` asserts the body cell renders the Alpine binding instead of a baked-in class. It fails without the change.

Unit + Feature suite: 2094 passed, 1 skipped.