### PR TITLE
Preserve pre-existing builder options in getScoutResults

### DIFF
--- a/src/DataTableServiceProvider.php
+++ b/src/DataTableServiceProvider.php
@@ -133,7 +133,11 @@ class DataTableServiceProvider extends ServiceProvider
                         $options['highlightPostTag'] = '</mark>';
                     }
 
-                    $searchResult = $this->options($options)->raw();
+                    // Merge into any options already on the builder (e.g. the hybrid
+                    // semantic-search settings a model sets in its search() override).
+                    // Scout's options() replaces the whole array, so overwriting it here
+                    // would silently drop those and fall back to a keyword-only search.
+                    $searchResult = $this->options(array_merge($this->options, $options))->raw();
 
                     $hits = Arr::keyBy(data_get($searchResult, 'hits'), $keyName);
                     unset($searchResult['hits']);


### PR DESCRIPTION
## Problem

`getScoutResults` applies its `limit`/`offset`/highlight options with Scout's `options()`, which **replaces** the whole options array rather than merging. Any options already set on the builder are silently dropped — in particular the Meilisearch **hybrid** semantic-search settings a model adds in its `search()` override. The datatable search then runs keyword-only, so a purely semantic query (a term not literally present in any document) returns nothing and falls through to the DB `LIKE` fallback.

## Fix

Merge the new options into whatever is already on the builder instead of replacing:

```php
$searchResult = $this->options(array_merge($this->options, $options))->raw();
```

Verified live: the same query that returned 0 rows via the datatable path now returns the expected semantically-ranked hits; keyword searches are unaffected.