### PR TITLE
Show a semantic relevance score on datatable search hits

### DIFF
--- a/config/tall-datatables.php
+++ b/config/tall-datatables.php
@@ -58,4 +58,20 @@ return [
     'models' => [
         'datatable_user_setting' => TeamNiftyGmbH\DataTable\Models\DatatableUserSetting::class,
     ],
+
+    'scout' => [
+        /*
+        |----------------------------------------------------------------------
+        | Ranking Score Threshold
+        |----------------------------------------------------------------------
+        |
+        | When a model uses Meilisearch hybrid (semantic) search, results carry
+        | a per-hit relevance score between 0 and 1. Set this to a float in that
+        | range to drop hits below the threshold from the results. Leave it
+        | null (default) to disable filtering and keep all hits.
+        |
+        */
+
+        'ranking_score_threshold' => env('TALL_DATATABLES_RANKING_SCORE_THRESHOLD'),
+    ],
 ];

--- a/resources/views/components/layouts/partials/table-row.blade.php
+++ b/resources/views/components/layouts/partials/table-row.blade.php
@@ -34,19 +34,26 @@
             class="border-b border-gray-100 px-3 py-2.5 text-sm whitespace-nowrap dark:border-secondary-700/50/50"
         >
             <div
-                {{ $selectAttributes->merge(['class' => 'flex justify-center']) }}
+                {{ $selectAttributes->merge(['class' => 'flex items-center justify-center gap-1']) }}
             >
                 <x-checkbox
                     x-on:click.stop="$wire.toggleSelected({{ json_encode($record[$modelKeyName] ?? $index) }})"
                     x-bind:checked="$wire.selected.includes('*') ? !$wire.wildcardSelectExcluded.includes({{ json_encode($record[$modelKeyName] ?? $index) }}) : $wire.selected.includes({{ json_encode($record[$modelKeyName] ?? $index) }})"
                     sm
                 />
+                @isset($record['_relevance'])
+                    <x-badge flat light color="emerald" :text="$record['_relevance'] . '%'" />
+                @endisset
             </div>
         </td>
     @else
         <td
-            class="max-w-0 border-b border-gray-100 text-sm whitespace-nowrap dark:border-secondary-700/50"
-        ></td>
+            class="max-w-0 border-b border-gray-100 px-1 text-sm whitespace-nowrap dark:border-secondary-700/50"
+        >
+            @isset($record['_relevance'])
+                <x-badge flat light color="emerald" :text="$record['_relevance'] . '%'" />
+            @endisset
+        </td>
     @endif
     @foreach ($enabledCols as $col)
         @php

--- a/src/DataTableServiceProvider.php
+++ b/src/DataTableServiceProvider.php
@@ -120,7 +120,16 @@ class DataTableServiceProvider extends ServiceProvider
                     $options = [
                         'limit' => $perPage,
                         'offset' => max(($page - 1) * $perPage, 0),
+                        // Request the per-hit relevance score so semantic (hybrid) search
+                        // results can be surfaced in the UI. Cheap to request even when a
+                        // model only ever does keyword search.
+                        'showRankingScore' => true,
                     ];
+
+                    $rankingScoreThreshold = config('tall-datatables.scout.ranking_score_threshold');
+                    if (is_numeric($rankingScoreThreshold)) {
+                        $options['rankingScoreThreshold'] = (float) $rankingScoreThreshold;
+                    }
 
                     if ($highlight === []) {
                         // No highlighting requested (e.g. an over-fetch that only needs the

--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -522,6 +522,13 @@ trait BuildsQueries
                         $itemArray[$key] = ['raw' => $raw, 'display' => $highlighted];
                     }
 
+                    // Semantic (hybrid) search score, 0..1, only present when the model's
+                    // search() requested it. Expose it as a rounded percent for display.
+                    $score = data_get($query->hits, $item->getKey() . '._rankingScore');
+                    if ($score !== null) {
+                        $itemArray['_relevance'] = (int) round($score * 100);
+                    }
+
                     return $itemArray;
                 }
             );

--- a/tests/Feature/BuildsQueriesTest.php
+++ b/tests/Feature/BuildsQueriesTest.php
@@ -2394,6 +2394,35 @@ describe('buildSearch with Scout Searchable model', function (): void {
             ->toHaveKey('raw');
         expect($data['data'][0]['title']['display'])->toContain('<mark>');
     });
+
+    it('exposes _relevance as a rounded percent when a hit carries a _rankingScore', function (): void {
+        config(['scout.driver' => 'collection']);
+
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Semantic Match Post']);
+
+        $component = Livewire::test(Tests\Fixtures\Livewire\RankingScoreSearchableDataTable::class);
+        $component->set('search', 'Semantic');
+        $component->call('loadData');
+
+        $data = $component->instance()->getDataForTesting();
+
+        expect($data['data'])->not->toBeEmpty();
+        expect($data['data'][0]['_relevance'])->toBe(88);
+    });
+
+    it('omits _relevance when no _rankingScore is present on the hit', function (): void {
+        config(['scout.driver' => 'collection']);
+
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Scout Match Post']);
+
+        $component = Livewire::test(Tests\Fixtures\Livewire\IdEnabledSearchableDataTable::class);
+        $component->set('search', 'Scout');
+        $component->call('loadData');
+
+        $data = $component->instance()->getDataForTesting();
+
+        expect($data['data'][0])->not->toHaveKey('_relevance');
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/Feature/ServiceProviderTest.php
+++ b/tests/Feature/ServiceProviderTest.php
@@ -544,6 +544,36 @@ describe('DataTableServiceProvider', function (): void {
                 ->toHaveKey('ids')
                 ->toHaveKey('searchResult');
         });
+
+        it('getScoutResults macro requests the ranking score and omits the threshold by default', function (): void {
+            if (! class_exists(Laravel\Scout\Builder::class)) {
+                $this->markTestSkipped('Scout not installed');
+            }
+
+            config(['scout.driver' => 'collection', 'tall-datatables.scout.ranking_score_threshold' => null]);
+
+            $builder = Tests\Fixtures\Models\SearchablePost::search('Scout');
+            $builder->getScoutResults();
+
+            expect($builder->options)
+                ->toHaveKey('showRankingScore', true)
+                ->not->toHaveKey('rankingScoreThreshold');
+        });
+
+        it('getScoutResults macro applies the ranking score threshold from config', function (): void {
+            if (! class_exists(Laravel\Scout\Builder::class)) {
+                $this->markTestSkipped('Scout not installed');
+            }
+
+            config(['scout.driver' => 'collection', 'tall-datatables.scout.ranking_score_threshold' => 0.5]);
+
+            $builder = Tests\Fixtures\Models\SearchablePost::search('Scout');
+            $builder->getScoutResults();
+
+            expect($builder->options)
+                ->toHaveKey('showRankingScore', true)
+                ->toHaveKey('rankingScoreThreshold', 0.5);
+        });
     });
 
     describe('Blade directive rendering via Blade::compileString', function (): void {

--- a/tests/Fixtures/Livewire/RankingScoreSearchableDataTable.php
+++ b/tests/Fixtures/Livewire/RankingScoreSearchableDataTable.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Fixtures\Livewire;
+
+use Illuminate\Database\Eloquent\Builder;
+use TeamNiftyGmbH\DataTable\DataTable;
+use Tests\Fixtures\Models\SearchablePost;
+
+class RankingScoreSearchableDataTable extends DataTable
+{
+    public array $enabledCols = [
+        'id',
+        'title',
+        'content',
+    ];
+
+    protected string $model = SearchablePost::class;
+
+    /**
+     * Override to simulate a Meilisearch hybrid-search hit carrying a
+     * per-row _rankingScore, without needing a live Meilisearch instance.
+     */
+    protected function buildSearch(bool $unpaginated = false): Builder
+    {
+        $query = SearchablePost::query();
+
+        if ($this->search && ! $unpaginated) {
+            $hits = SearchablePost::query()
+                ->where('title', 'like', '%' . $this->search . '%')
+                ->get()
+                ->mapWithKeys(function (SearchablePost $post): array {
+                    return [
+                        $post->getKey() => [
+                            'id' => $post->getKey(),
+                            'title' => $post->title,
+                            'content' => $post->content,
+                            '_rankingScore' => 0.876,
+                        ],
+                    ];
+                })
+                ->all();
+
+            $query->whereKey(array_keys($hits));
+            $query->hits = $hits;
+            $query->scout_pagination = [
+                'estimatedTotalHits' => count($hits),
+                'limit' => $this->perPage,
+                'offset' => 0,
+            ];
+        }
+
+        return $query;
+    }
+}


### PR DESCRIPTION
When a datatable searches a model via Meilisearch hybrid (semantic) search, results are ranked by an `_rankingScore` that was neither requested nor shown.

## Changes

- `getScoutResults` now sends `showRankingScore: true`, so every hit carries its `_rankingScore`. It also reads an optional `tall-datatables.scout.ranking_score_threshold` config (default `null` = off) and passes it as Meilisearch's `rankingScoreThreshold` to drop low-relevance noise when configured.
- The hits-mapping surfaces the score per row as `_relevance` (integer percent, e.g. `0.876 → 88`).
- The row view renders a small emerald badge showing `NN%` in the existing leading cell, only when `_relevance` is present — so keyword/DB-search tables are unchanged.

## Tests

Added coverage for the option flags (showRankingScore always on; rankingScoreThreshold present only when configured) and the per-row `_relevance` mapping (present with a score, absent without).

Note: the badge's visual placement was verified through component tests, not a browser — worth an eyeball on a live semantic-search table.