### PR TITLE
Show the semantic relevance score in its own column

### DIFF
--- a/resources/views/components/layouts/partials/table-row.blade.php
+++ b/resources/views/components/layouts/partials/table-row.blade.php
@@ -2,6 +2,7 @@
     'record' => [],
     'index' => 0,
     'isSelectable' => false,
+    'hasRelevance' => false,
     'selectValue' => 'record.id',
     'selectAttributes' => new \Illuminate\View\ComponentAttributeBag(),
     'rowAttributes' => new \Illuminate\View\ComponentAttributeBag(),
@@ -41,17 +42,19 @@
                     x-bind:checked="$wire.selected.includes('*') ? !$wire.wildcardSelectExcluded.includes({{ json_encode($record[$modelKeyName] ?? $index) }}) : $wire.selected.includes({{ json_encode($record[$modelKeyName] ?? $index) }})"
                     sm
                 />
-                @isset($record['_relevance'])
-                    <x-badge flat light color="emerald" :text="$record['_relevance'] . '%'" />
-                @endisset
             </div>
         </td>
     @else
         <td
             class="max-w-0 border-b border-gray-100 px-1 text-sm whitespace-nowrap dark:border-secondary-700/50"
+        ></td>
+    @endif
+    @if ($hasRelevance)
+        <td
+            class="border-b border-gray-100 px-2 py-2.5 text-sm whitespace-nowrap dark:border-secondary-700/50"
         >
             @isset($record['_relevance'])
-                <x-badge flat light color="emerald" :text="$record['_relevance'] . '%'" />
+                <x-badge flat light color="emerald" :text="$record['_relevance'] . '%'" sm />
             @endisset
         </td>
     @endif

--- a/resources/views/components/layouts/table.blade.php
+++ b/resources/views/components/layouts/table.blade.php
@@ -27,6 +27,9 @@
         <table class="dark:bg-secondary-800 min-w-full border-collapse bg-white text-sm text-gray-500 dark:text-gray-50"
             x-bind:class="Object.keys($wire.colWidths || {}).length > 0 ? 'table-fixed' : 'table-auto'"
         >
+            @php
+                $hasRelevance = collect($this->data['data'] ?? [])->contains(fn ($r) => isset($r['_relevance']));
+            @endphp
             <thead style="z-index: 9">
                 @if ($hasHead)
                     <tr>
@@ -51,6 +54,9 @@
                             </x-tall-datatables::table.head-cell>
                         @else
                             <th class="max-w-0"></th>
+                        @endif
+                        @if ($hasRelevance)
+                            <x-tall-datatables::table.head-cell class="w-16 whitespace-nowrap">{{ __('Score') }}</x-tall-datatables::table.head-cell>
                         @endif
                         <template x-for="col in $wire.enabledCols" x-bind:key="col">
                             <x-tall-datatables::table.head-cell
@@ -202,6 +208,9 @@
                                         </div>
                                     </template>
                                 </td>
+                                @if ($hasRelevance)
+                                    <td class="dark:bg-secondary-700/30 border-b border-l border-gray-100 bg-gray-50/50 px-0 py-0 dark:border-secondary-700/50"></td>
+                                @endif
                                 <template x-for="col in $wire.enabledCols" x-bind:key="'filter-' + rowIndex + '-' + col">
                                     <td
                                         class="group/cell dark:bg-secondary-700/30 border-b border-l border-gray-100 bg-gray-50/50 px-0 py-0 dark:border-secondary-700/50"
@@ -336,6 +345,9 @@
                 </tr>
                 @island(name: 'body')
                 @php extract($this->getIslandData()); @endphp
+                @php
+                    $hasRelevance = collect($this->data['data'] ?? [])->contains(fn ($r) => isset($r['_relevance']));
+                @endphp
                 @if (! $this->initialized)
                     <tr>
                         <td colspan="100%" class="h-24 w-24 p-8"></td>
@@ -379,6 +391,7 @@
                             :record="$record"
                             :index="$index"
                             :is-selectable="$isSelectable"
+                            :has-relevance="$hasRelevance"
                             :select-value="$selectValue"
                             :select-attributes="$selectAttributes"
                             :row-attributes="$rowAttributes"


### PR DESCRIPTION
Moves the relevance % badge out of the checkbox/spacer cell (where it overlapped the first column) into a dedicated leading column, shown only when the results carry relevance scores. Computes the flag both for the header and inside the body Livewire island so header and rows stay aligned. Verified live: the tickets search shows a clean "Score" column with descending % badges next to unbroken ticket numbers.