### PR TITLE
Compare string columns numerically for numeric filter values

### DIFF
--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -25,6 +25,7 @@ use TeamNiftyGmbH\DataTable\Contracts\InteractsWithDataTables;
 use TeamNiftyGmbH\DataTable\Formatters\ArrayFormatter;
 use TeamNiftyGmbH\DataTable\Formatters\FormatterRegistry;
 use TeamNiftyGmbH\DataTable\Formatters\StringFormatter;
+use TeamNiftyGmbH\DataTable\Helpers\SchemaInfo;
 use TeamNiftyGmbH\DataTable\Helpers\SessionFilter;
 use Throwable;
 
@@ -135,7 +136,18 @@ trait BuildsQueries
                 try {
                     if ($filter['operator'] === 'between') {
                         if (is_array($filter['value']) && count($filter['value']) === 2) {
-                            $query->whereBetween($filter['column'], $filter['value']);
+                            if (
+                                is_numeric($filter['value'][0])
+                                && is_numeric($filter['value'][1])
+                                && $this->isStringColumn($query, $filter['column'])
+                            ) {
+                                $query->whereRaw(
+                                    $this->numericColumnExpression($query, $filter['column']) . ' between ? and ?',
+                                    [$filter['value'][0], $filter['value'][1]]
+                                );
+                            } else {
+                                $query->whereBetween($filter['column'], $filter['value']);
+                            }
                         }
                     } elseif (in_array($filter['operator'], ['starts with', 'ends with', 'contains', 'does not contain'])) {
                         $value = $filter['value'] ?? '';
@@ -159,7 +171,18 @@ trait BuildsQueries
                         $value = $filter['value'] ?? null;
 
                         if ($column && $operator && ($value !== null && $value !== '')) {
-                            $query->where($column, $operator, $value);
+                            if (
+                                in_array($operator, ['<', '<=', '>', '>='])
+                                && is_numeric($value)
+                                && $this->isStringColumn($query, $column)
+                            ) {
+                                $query->whereRaw(
+                                    $this->numericColumnExpression($query, $column) . ' ' . $operator . ' ?',
+                                    [$value]
+                                );
+                            } else {
+                                $query->where($column, $operator, $value);
+                            }
                         }
                     }
                 } catch (Throwable) {
@@ -1014,6 +1037,11 @@ trait BuildsQueries
         return str_contains($col, 'date') || str_ends_with($col, '_at');
     }
 
+    private function isStringColumn(Builder $query, string $column): bool
+    {
+        return SchemaInfo::forModel($query->getModel())->attribute($column)?->phpType === 'string';
+    }
+
     /**
      * Migrate old userFilters format (with 'text' key) to unified format.
      */
@@ -1102,6 +1130,15 @@ trait BuildsQueries
         }
 
         return $trimmed;
+    }
+
+    /**
+     * Text columns compare lexicographically, so '80331' <= '9999' would be true.
+     * Cast them so a numeric filter value is compared as a number.
+     */
+    private function numericColumnExpression(Builder $query, string $column): string
+    {
+        return 'cast(' . $query->getGrammar()->wrap($query->qualifyColumn($column)) . ' as decimal(20,6))';
     }
 
     private function parseDateValue(string $value): ?string

--- a/tests/Feature/NumericStringColumnFilterTest.php
+++ b/tests/Feature/NumericStringColumnFilterTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use Livewire\Livewire;
+use Tests\Fixtures\Livewire\PostDataTable;
+
+beforeEach(function (): void {
+    $this->user = createTestUser(['name' => 'Zip User', 'email' => 'zip@example.com']);
+    $this->actingAs($this->user);
+
+    // "zip codes" stored in a string column: lexicographically '80331' < '9999',
+    // numerically it is not.
+    foreach (['1010', '9999', '10115', '80331'] as $title) {
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => $title]);
+    }
+});
+
+it('compares a string column numerically for less or equal', function (): void {
+    $component = Livewire::test(PostDataTable::class);
+    $component->set('userFilters', [
+        [['column' => 'title', 'operator' => '<=', 'value' => 9999]],
+    ]);
+    $component->call('loadData');
+
+    $data = $component->instance()->getDataForTesting();
+
+    expect(collect($data['data'])->pluck('title')->sort()->values()->toArray())
+        ->toBe(['1010', '9999']);
+});
+
+it('compares a string column numerically for greater than', function (): void {
+    $component = Livewire::test(PostDataTable::class);
+    $component->set('userFilters', [
+        [['column' => 'title', 'operator' => '>', 'value' => 9999]],
+    ]);
+    $component->call('loadData');
+
+    $data = $component->instance()->getDataForTesting();
+
+    expect(collect($data['data'])->pluck('title')->sort()->values()->toArray())
+        ->toBe(['10115', '80331']);
+});
+
+it('compares a string column numerically for between', function (): void {
+    $component = Livewire::test(PostDataTable::class);
+    $component->set('userFilters', [
+        [['column' => 'title', 'operator' => 'between', 'value' => [1000, 9999]]],
+    ]);
+    $component->call('loadData');
+
+    $data = $component->instance()->getDataForTesting();
+
+    expect(collect($data['data'])->pluck('title')->sort()->values()->toArray())
+        ->toBe(['1010', '9999']);
+});
+
+it('still compares a string column as text when the value is not numeric', function (): void {
+    createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Alpha']);
+    createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Zulu']);
+
+    $component = Livewire::test(PostDataTable::class);
+    $component->set('userFilters', [
+        [['column' => 'title', 'operator' => '>', 'value' => 'Beta']],
+    ]);
+    $component->call('loadData');
+
+    $data = $component->instance()->getDataForTesting();
+
+    expect(collect($data['data'])->pluck('title')->toArray())->toContain('Zulu')
+        ->not->toContain('Alpha');
+});


### PR DESCRIPTION
Comparison filters (`<`, `<=`, `>`, `>=`, `between`) on text columns were evaluated lexicographically by the database, so a filter like `zip <= 9999` matched `'80331'` and returned nearly every row.

When the filter value is numeric and the column is a string column, the column is now cast to a decimal before comparing. Text values keep the existing text comparison, and numeric columns are untouched so their indexes still apply.

Covered by `tests/Feature/NumericStringColumnFilterTest.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)