### PR TITLE
Qualify filter columns so relation filters stay unambiguous

### DIFF
--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -131,8 +131,12 @@ trait BuildsQueries
                     }
                 }
             } elseif (in_array($filter['operator'], ['is null', 'is not null'])) {
+                // Qualify so the column stays unambiguous inside relation subqueries that join
+                $filter['column'] = $query->qualifyColumn($filter['column']);
                 $this->applyFilterWhereNull($query, $filter);
             } else {
+                $filter['column'] = $query->qualifyColumn($filter['column']);
+
                 try {
                     if ($filter['operator'] === 'between') {
                         if (is_array($filter['value']) && count($filter['value']) === 2) {
@@ -1039,7 +1043,8 @@ trait BuildsQueries
 
     private function isStringColumn(Builder $query, string $column): bool
     {
-        return SchemaInfo::forModel($query->getModel())->attribute($column)?->phpType === 'string';
+        return SchemaInfo::forModel($query->getModel())
+            ->attribute(Str::afterLast($column, '.'))?->phpType === 'string';
     }
 
     /**
@@ -1175,8 +1180,8 @@ trait BuildsQueries
     {
         $trimmed = trim($value);
 
-        // Support "is null" / "is not null" (case insensitive)
-        if (preg_match('/^(is\s+null|is\s+not\s+null)$/i', $trimmed, $matches)) {
+        // Support "is null" / "is not null" (case insensitive, optionally quoted)
+        if (preg_match('/^["\']?(is\s+null|is\s+not\s+null)["\']?$/i', $trimmed, $matches)) {
             return [
                 'column' => $column,
                 'operator' => strtolower(preg_replace('/\s+/', ' ', $matches[1])),

--- a/tests/Feature/RelationFilterColumnQualificationTest.php
+++ b/tests/Feature/RelationFilterColumnQualificationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Livewire\Livewire;
+use Tests\Fixtures\Livewire\CommentWithPostUserDataTable;
+
+beforeEach(function (): void {
+    $this->user = createTestUser();
+    $this->actingAs($this->user);
+
+    $this->comment = createTestComment(['user_id' => $this->user->getKey()]);
+});
+
+it('qualifies relation filter columns so a through join does not throw ambiguous column errors', function (): void {
+    $component = Livewire::test(CommentWithPostUserDataTable::class);
+    $component->set('userFilters', [
+        [['column' => 'post_user.id', 'operator' => '=', 'value' => $this->user->getKey()]],
+    ]);
+    $component->call('loadData');
+
+    $data = $component->instance()->getDataForTesting();
+
+    expect(collect($data['data'])->pluck('id')->toArray())->toBe([$this->comment->getKey()]);
+});
+
+it('qualifies relation filter columns for is null filters', function (): void {
+    $component = Livewire::test(CommentWithPostUserDataTable::class);
+    $component->set('userFilters', [
+        [['column' => 'post_user.deleted_at', 'operator' => 'is null', 'value' => null]],
+    ]);
+    $component->call('loadData');
+
+    $data = $component->instance()->getDataForTesting();
+
+    expect(collect($data['data'])->pluck('id')->toArray())->toBe([$this->comment->getKey()]);
+});
+
+it('qualifies relation filter columns for negated filters', function (): void {
+    $component = Livewire::test(CommentWithPostUserDataTable::class);
+    $component->set('userFilters', [
+        [['column' => 'post_user.id', 'operator' => '!=', 'value' => $this->user->getKey()]],
+    ]);
+    $component->call('loadData');
+
+    $data = $component->instance()->getDataForTesting();
+
+    expect($data['data'])->toBeEmpty();
+});
+
+it('parses a quoted is null text filter as a null check', function (): void {
+    $component = Livewire::test(CommentWithPostUserDataTable::class);
+    $component->set('userFilters', ['text' => ['post_user.deleted_at' => '"is null"']]);
+    $component->call('loadData');
+
+    $data = $component->instance()->getDataForTesting();
+
+    expect(collect($data['data'])->pluck('id')->toArray())->toBe([$this->comment->getKey()]);
+});


### PR DESCRIPTION
Filters applied inside a `whereHas` subquery used the bare column name. For a relation whose subquery joins more than one table, such as a `hasOneThrough` or a nested relation path, the database cannot tell which table the column belongs to and rejects the query.

Filtering contacts by `mainAddress.country.name` failed with `Column 'name' in where clause is ambiguous`, because the subquery joins both `countries` and `addresses`. Eager load selects were already qualified for exactly this reason, filters were not.

## Changes

- Qualify the column with the table of the builder the filter is applied to. On the top level query this does not change behaviour, inside a relation subquery it resolves the ambiguity.
- `isStringColumn` looks up the attribute by its bare name, so the numeric comparison for string columns keeps working on qualified columns. `numericColumnExpression` already leaves an already qualified column untouched.
- Accept a quoted `"is null"` / `"is not null"` text filter.

## Tests

`tests/Feature/RelationFilterColumnQualificationTest.php` covers the through join, the negated operator, the null check and the quoted null operator. All four fail without the change.