### PR TITLE
Bound how many to-many hops a relation column may chain

### DIFF
--- a/config/tall-datatables.php
+++ b/config/tall-datatables.php
@@ -44,6 +44,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Max Relation Column To-Many Hops
+    |--------------------------------------------------------------------------
+    |
+    | Every to-many hop in a column path multiplies the loaded records by the cap
+    | above, so orders.positions.tags.name already pulls 50^3 records per row. A
+    | relation tree also lets a user walk a self referencing relation in a circle,
+    | which never terminates on its own. This caps how many to-many hops a single
+    | column path may contain, columns beyond it are dropped.
+    | Set to 0 to disable the cap.
+    |
+    */
+
+    'max_relation_column_to_many_hops' => env('TALL_DATATABLES_MAX_RELATION_COLUMN_TO_MANY_HOPS', 1),
+
+    /*
+    |--------------------------------------------------------------------------
     | Search Route
     |--------------------------------------------------------------------------
     |

--- a/src/Traits/DataTables/SupportsRelations.php
+++ b/src/Traits/DataTables/SupportsRelations.php
@@ -321,6 +321,7 @@ trait SupportsRelations
         $filterable = [];
         $sortable = [];
         $relatedFormatters = [];
+        $maxToManyHops = config('tall-datatables.max_relation_column_to_many_hops', 1);
         $this->withCountRelations = [];
 
         foreach (array_merge($this->enabledCols, $this->getReturnKeys()) as $enabledCol) {
@@ -340,8 +341,15 @@ trait SupportsRelations
                 continue;
             }
 
+            // a column that turns out to be unusable must not leave its eager loads
+            // behind, every surviving hop is still loaded and hydrated for each row
+            $withBeforeCol = $with;
+            $relationTablesBeforeCol = $relationTables;
+
             $segments = explode('.', $enabledCol);
             $fieldName = array_pop($segments);
+
+            $toManyHops = 0;
 
             $path = null;
             $model = null;
@@ -359,6 +367,30 @@ trait SupportsRelations
                     }
                 } catch (BadMethodCallException) {
                     $this->enabledCols = array_values(array_diff($this->enabledCols, [$enabledCol]));
+                    $with = $withBeforeCol;
+                    $relationTables = $relationTablesBeforeCol;
+
+                    continue 2;
+                }
+
+                // Each to-many hop multiplies the hydrated object graph by
+                // max_relation_column_values, so a path that chains several of them
+                // (comments.post.comments.body, or a self referencing morph such as
+                // category.categorizables.categories) exhausts the worker long before
+                // it renders. Relation trees let a user click such a path together, so
+                // the column is dropped rather than trusted.
+                if ($maxToManyHops > 0
+                    && (
+                        $relationInstance instanceof HasMany
+                        || $relationInstance instanceof HasManyThrough
+                        || $relationInstance instanceof BelongsToMany
+                        || $relationInstance instanceof MorphMany
+                    )
+                    && ++$toManyHops > $maxToManyHops
+                ) {
+                    $this->enabledCols = array_values(array_diff($this->enabledCols, [$enabledCol]));
+                    $with = $withBeforeCol;
+                    $relationTables = $relationTablesBeforeCol;
 
                     continue 2;
                 }

--- a/tests/Feature/ChainedToManyRelationColumnTest.php
+++ b/tests/Feature/ChainedToManyRelationColumnTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Support\Facades\Cache;
+use Livewire\Livewire;
+use Tests\Fixtures\Livewire\ChainedToManyDataTable;
+
+beforeEach(function (): void {
+    Cache::flush();
+
+    $this->user = createTestUser();
+    $this->actingAs($this->user);
+
+    $post = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Root']);
+    createTestComment(['post_id' => $post->getKey(), 'user_id' => $this->user->getKey()]);
+});
+
+function constructWithOf(object $component): array
+{
+    return (fn () => $this->constructWith())->call($component);
+}
+
+it('drops a column that chains more than one to-many relation', function (): void {
+    $component = Livewire::test(ChainedToManyDataTable::class);
+
+    expect($component->get('enabledCols'))
+        ->not->toContain('comments.post.comments.user.posts.title');
+});
+
+it('does not eager load any hop of the chained to-many path', function (): void {
+    $with = constructWithOf(Livewire::test(ChainedToManyDataTable::class)->instance())[0];
+
+    // not even a partial hop of the dropped path may survive, each one multiplies
+    // the hydrated object graph by max_relation_column_values
+    expect($with)->each->not->toStartWith('comments.post');
+});
+
+it('keeps columns with a single to-many hop and none at all', function (): void {
+    $component = Livewire::test(ChainedToManyDataTable::class);
+
+    expect($component->get('enabledCols'))
+        ->toContain('title')
+        ->toContain('user.name')
+        ->toContain('comments.body');
+});
+
+it('keeps the chained column when the cap is disabled', function (): void {
+    config(['tall-datatables.max_relation_column_to_many_hops' => 0]);
+
+    $component = Livewire::test(ChainedToManyDataTable::class);
+
+    expect($component->get('enabledCols'))
+        ->toContain('comments.post.comments.user.posts.title');
+});

--- a/tests/Fixtures/Livewire/ChainedToManyDataTable.php
+++ b/tests/Fixtures/Livewire/ChainedToManyDataTable.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Fixtures\Livewire;
+
+use TeamNiftyGmbH\DataTable\DataTable;
+use Tests\Fixtures\Models\Post;
+
+class ChainedToManyDataTable extends DataTable
+{
+    public array $enabledCols = [
+        'title',
+        // no to-many hop
+        'user.name',
+        // a single to-many hop, the supported case
+        'comments.body',
+        // three to-many hops: comments -> post -> comments -> user -> posts
+        'comments.post.comments.user.posts.title',
+    ];
+
+    protected string $model = Post::class;
+}


### PR DESCRIPTION
## Problem

A column path such as `comments.post.comments.body` is walked segment by segment in `constructWith()`, and every relation on the way is eager loaded. Each **to-many** hop multiplies the hydrated object graph by `max_relation_column_values`, so a path with `n` of them pulls up to `50^n` records per row.

The relation tree offers relations one level at a time and never notices when a path returns to a model it has already visited. A self referencing relation can therefore be clicked into a circle. `Category` registers a `morphedByMany` back to every categorizable model in `booted()`, so a categorizable model yields:

```
category -> oligoFailures -> categories -> oligoFailures -> categories
```

Four to-many hops. Such a column exhausts the execution time limit during loading, before a single row renders, and it is persisted into the user's datatable settings, so the list keeps dying on every subsequent load.

## Change

- Cap the number of to-many hops a single column path may contain, `max_relation_column_to_many_hops` (default `1`, `0` disables the cap). Columns beyond it are dropped, matching how an unresolvable relation is already handled.
- Dropping a column now rolls back the eager loads its walk had already registered. Without this the surviving hops kept the full cost even though the column was gone. The pre-existing drop for an unresolvable relation leaked the same way and is fixed along with it.

Paths without a to-many hop are untouched however deep, so a chain of `belongsTo` such as `position.order.contact.mainAddress.name` keeps working. A single to-many hop such as `comments.body` also keeps working, which is the case `max_relation_column_values` already bounds.

## Tests

`tests/Feature/ChainedToManyRelationColumnTest.php` covers the drop, that no partial hop of the dropped path survives in the eager loads, that zero-hop and single-hop columns are untouched, and that the cap can be disabled.

Full Feature + Unit suite: 2103 passing. The two `AssetControllerTest` failures are pre-existing and reproduce on a clean checkout, they glob for built frontend assets that are not present locally.