### PR TITLE
Match missing relations when filtering a relation column for null

### DIFF
--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -105,6 +105,24 @@ trait BuildsQueries
                     $this->applyFilterWhereHas($query, $filter['relation']);
                 } elseif ($filter['value'] === '%!*%') {
                     $this->applyFilterWhereDoesntHave($query, $filter['relation']);
+                } elseif (($filter['operator'] ?? null) === 'is null') {
+                    // A missing relation has no row to test, so a plain whereHas would drop
+                    // exactly the records this filter looks for.
+                    try {
+                        $query->where(function (Builder $subQuery) use ($type, $filter): void {
+                            $relation = $filter['relation'];
+                            unset($filter['relation']);
+
+                            $subQuery->whereDoesntHave($relation)
+                                ->orWhereHas($relation, function (Builder $relationQuery) use ($type, $filter) {
+                                    $this->addFilter($relationQuery, $type, $filter);
+
+                                    return $relationQuery;
+                                });
+                        });
+                    } catch (BadMethodCallException) {
+                        // Relation does not exist on model — skip this filter
+                    }
                 } elseif (array_key_exists($filter['operator'] ?? '', $negatedRelationOperators)) {
                     $filter['operator'] = $negatedRelationOperators[$filter['operator']];
 

--- a/tests/Feature/RelationIsNullFilterTest.php
+++ b/tests/Feature/RelationIsNullFilterTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Livewire\Livewire;
+use Tests\Fixtures\Livewire\ProductDataTable;
+
+beforeEach(function (): void {
+    $this->actingAs(createTestUser());
+
+    $this->withoutUser = createTestProduct(['user_id' => null]);
+    $this->withUser = createTestProduct();
+});
+
+function relationIsNullFilterResult(array $filter): array
+{
+    $component = Livewire::test(ProductDataTable::class);
+    $component->set('userFilters', [[$filter]]);
+    $component->call('loadData');
+
+    return collect($component->instance()->getDataForTesting()['data'])->pluck('id')->toArray();
+}
+
+it('returns records without the relation when filtering a relation column for null', function (): void {
+    expect(relationIsNullFilterResult([
+        'column' => 'user.name',
+        'operator' => 'is null',
+        'value' => null,
+    ]))->toBe([$this->withoutUser->getKey()]);
+});
+
+it('returns records without the relation for a quoted is null text filter', function (): void {
+    $component = Livewire::test(ProductDataTable::class);
+    $component->set('userFilters', ['text' => ['user.name' => '"is null"']]);
+    $component->call('loadData');
+
+    $data = $component->instance()->getDataForTesting();
+
+    expect(collect($data['data'])->pluck('id')->toArray())->toBe([$this->withoutUser->getKey()]);
+});
+
+it('keeps records with the relation out of the is not null result only when the relation is missing', function (): void {
+    expect(relationIsNullFilterResult([
+        'column' => 'user.name',
+        'operator' => 'is not null',
+        'value' => null,
+    ]))->toBe([$this->withUser->getKey()]);
+});


### PR DESCRIPTION
## Problem

Filters on a relation column (e.g. `country.name`) are always applied inside a `whereHas` subquery. For the `is null` operator that is wrong: a record without a related row has no row for the subquery to test, so `whereHas` drops exactly the records the filter is looking for. Filtering an address list for "country is null" returned an empty result instead of the addresses that have no country.

## Fix

For the `is null` operator on a relation column the filter now matches both cases:

- the relation is missing entirely (`whereDoesntHave`)
- the relation exists and the filtered column is null (`whereHas` + `whereNull`)

`is not null` is unchanged and still requires the relation to exist.

## Test

`tests/Feature/RelationIsNullFilterTest.php` — a product with and one without a user, filtered on `user.name`. Both `is null` cases fail without the change (empty result), the `is not null` case guards the unchanged behaviour.

Full suite green except the two `AssetControllerTest` cases that are also red on a clean `main` (they need built dist assets).