### PR TITLE
Make the column resize handle wide enough to grab

### DIFF
--- a/resources/views/components/layouts/table.blade.php
+++ b/resources/views/components/layouts/table.blade.php
@@ -158,8 +158,25 @@
                                     @endif
                                 </div>
                                 @if ($isResizable)
+                                    {{--
+                                        A hand on a mouse does not land on a
+                                        hairline, and a list read at seventy
+                                        percent zoom gets less than one device
+                                        pixel per CSS pixel, so the four pixels
+                                        this used to be were not a small target
+                                        but an unreachable one, and the drag
+                                        read as a feature that was not there.
+
+                                        It stays inside the cell rather than
+                                        straddling the border: a column with a
+                                        pinned width has its cell clipped, and
+                                        anything hanging over the edge would be
+                                        cut off. Ten pixels still fall entirely
+                                        within the cell's right padding, so no
+                                        label is ever covered.
+                                    --}}
                                     <div
-                                        class="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary-400 transition-colors"
+                                        class="absolute right-0 top-0 bottom-0 w-2.5 cursor-col-resize hover:bg-primary-400 transition-colors"
                                         x-on:mousedown="startResize($event, col)"
                                     ></div>
                                 @endif

--- a/tests/Browser/ResizeAfterStoredWidthsBrowserTest.php
+++ b/tests/Browser/ResizeAfterStoredWidthsBrowserTest.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * A column may be dragged more than once.
+ *
+ * The first drag stores a width, and from then on the table lays itself out
+ * fixed and every heading is clipped instead of wrapped. Both of those are
+ * changes to the very cells the handle sits in, so the second drag is the one
+ * that tells whether the handle survived them.
+ */
+
+use Tests\Fixtures\Livewire\WrappedResizablePostDataTable;
+
+beforeEach(function (): void {
+    $manifestPath = dirname(__DIR__, 2) . '/dist/build/manifest.json';
+    if (! file_exists($manifestPath)) {
+        $this->markTestSkipped('Browser tests require built assets. Run: npm run build');
+    }
+
+    $this->user = createTestUser(['name' => 'Test User', 'email' => 'resize-twice@example.com']);
+
+    for ($i = 1; $i <= 60; $i++) {
+        createTestPost([
+            'user_id' => $this->user->getKey(),
+            'title' => "Post Title {$i}",
+            'content' => "Content {$i}",
+            'is_published' => true,
+        ]);
+    }
+});
+
+/**
+ * What flux puts on top of a table: the row of labels is carried along by a
+ * scroll driven animation so it stays in view. That animation transforms the
+ * row the handles sit in, which is why the drag is worth trying underneath it.
+ */
+const FLOATING_HEAD_STYLES = <<<'CSS'
+    [tall-datatable] thead tr:first-child {
+        position: relative;
+        z-index: 9;
+        animation: flux-table-head linear both;
+        animation-timeline: scroll(root block);
+        animation-range: var(--flux-head-start, 0px) var(--flux-head-end, 0px);
+    }
+
+    [tall-datatable] thead tr:first-child > * {
+        border-bottom-width: 0;
+        box-shadow: inset 0 -1px 0 var(--color-gray-200);
+    }
+
+    @keyframes flux-table-head {
+        to {
+            transform: translateY(var(--flux-head-travel, 0px));
+        }
+    }
+CSS;
+
+it('lets a column be dragged again once a width is stored', function (): void {
+    $page = visitLivewire(WrappedResizablePostDataTable::class);
+
+    $page->wait(2);
+
+    // The drag is aimed at the point the handle occupies, not at the handle
+    // itself, and the event goes to whatever actually sits there. A handle that
+    // has ended up underneath something else fails here the way it fails for a
+    // real hand on a real mouse.
+    $result = $page->script('() => {
+        const drag = (distance) => {
+            const handle = document.querySelectorAll(".cursor-col-resize")[0];
+            if (! handle) return { error: "no handle" };
+
+            const th = handle.closest("th");
+            const rect = handle.getBoundingClientRect();
+            const x = rect.left + rect.width / 2;
+            const y = rect.top + rect.height / 2;
+            const target = document.elementFromPoint(x, y);
+            const before = th.offsetWidth;
+
+            target.dispatchEvent(new MouseEvent("mousedown", { clientX: x, clientY: y, bubbles: true }));
+            document.dispatchEvent(new MouseEvent("mousemove", { clientX: x + distance, clientY: y, bubbles: true }));
+            document.dispatchEvent(new MouseEvent("mouseup", { clientX: x + distance, clientY: y, bubbles: true }));
+
+            return {
+                handleHit: target === handle,
+                topmost: target ? target.tagName + "." + (target.className || "") : null,
+                before,
+                after: th.offsetWidth,
+            };
+        };
+
+        return new Promise((resolve) => {
+            const first = drag(120);
+
+            // Long enough for the round trip that stores the width and for the
+            // re-render that follows it.
+            setTimeout(() => {
+                const second = drag(120);
+
+                setTimeout(() => resolve({ first, second }), 1500);
+            }, 2500);
+        });
+    }');
+
+    $data = is_array($result) && isset($result[0]) ? $result[0] : $result;
+
+    expect($data['first']['handleHit'])->toBeTrue()
+        ->and($data['first']['after'])->toBeGreaterThan($data['first']['before']);
+
+    expect($data['second']['handleHit'])->toBeTrue('the handle is no longer the topmost element at its own position, so no mouse can reach it')
+        ->and($data['second']['after'])->toBeGreaterThan($data['second']['before']);
+});
+
+it('lets a column be dragged while the head floats above the rows', function (): void {
+    $page = visitLivewire(WrappedResizablePostDataTable::class);
+
+    $page->wait(2);
+
+    $result = $page->script('() => {
+        const style = document.createElement("style");
+        style.textContent = ' . json_encode(FLOATING_HEAD_STYLES) . ';
+        document.head.appendChild(style);
+
+        const table = document.querySelector("table");
+        const wrapper = table.closest("div");
+        wrapper.setAttribute("tall-datatable", "");
+
+        const head = table.querySelector("thead");
+        const body = table.querySelector("tbody");
+        const labels = head.rows[0];
+        const headRect = head.getBoundingClientRect();
+        const bodyRect = body.getBoundingClientRect();
+        const travel = bodyRect.bottom - labels.offsetHeight - headRect.top;
+        const start = Math.max(0, headRect.top + window.scrollY);
+
+        labels.style.setProperty("--flux-head-start", start + "px");
+        labels.style.setProperty("--flux-head-end", (start + travel) + "px");
+        labels.style.setProperty("--flux-head-travel", travel + "px");
+
+        window.scrollTo(0, Math.round(start + travel / 2));
+
+        return new Promise((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => {
+                const handle = document.querySelectorAll(".cursor-col-resize")[0];
+                const th = handle.closest("th");
+                const rect = handle.getBoundingClientRect();
+                const x = rect.left + rect.width / 2;
+                const y = rect.top + rect.height / 2;
+                const target = document.elementFromPoint(x, y);
+                const before = th.offsetWidth;
+
+                target && target.dispatchEvent(new MouseEvent("mousedown", { clientX: x, clientY: y, bubbles: true }));
+                document.dispatchEvent(new MouseEvent("mousemove", { clientX: x + 120, clientY: y, bubbles: true }));
+                document.dispatchEvent(new MouseEvent("mouseup", { clientX: x + 120, clientY: y, bubbles: true }));
+
+                resolve({
+                    scrolled: window.scrollY,
+                    travel,
+                    handleHit: target === handle,
+                    topmost: target ? target.tagName + "." + (target.className || "") : null,
+                    before,
+                    after: th.offsetWidth,
+                });
+            }));
+        });
+    }');
+
+    $data = is_array($result) && isset($result[0]) ? $result[0] : $result;
+
+    expect($data['handleHit'])->toBeTrue('the floating head row has moved out from under its own handles')
+        ->and($data['after'])->toBeGreaterThan($data['before']);
+});

--- a/tests/Browser/ResizeHandleReachBrowserTest.php
+++ b/tests/Browser/ResizeHandleReachBrowserTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * A hand on a mouse does not land on the exact pixel of a column border, and a
+ * lab reading long lists side by side works at seventy or even fifty percent
+ * zoom, where every CSS pixel is worth half a real one. A grab area only a few
+ * pixels wide is therefore not a small target, it is one that cannot be hit at
+ * all, and the drag reads as a feature that does not exist.
+ */
+
+use Tests\Fixtures\Livewire\WrappedResizablePostDataTable;
+
+beforeEach(function (): void {
+    $manifestPath = dirname(__DIR__, 2) . '/dist/build/manifest.json';
+    if (! file_exists($manifestPath)) {
+        $this->markTestSkipped('Browser tests require built assets. Run: npm run build');
+    }
+
+    $this->user = createTestUser(['name' => 'Test User', 'email' => 'reach@example.com']);
+
+    for ($i = 1; $i <= 5; $i++) {
+        createTestPost([
+            'user_id' => $this->user->getKey(),
+            'title' => "Post Title {$i}",
+            'content' => "Content {$i}",
+            'is_published' => true,
+        ]);
+    }
+});
+
+it('gives the drag a grab area a mouse can hit', function (): void {
+    $page = visitLivewire(WrappedResizablePostDataTable::class);
+
+    $page->wait(2);
+
+    $result = $page->script('() => {
+        const handle = document.querySelectorAll(".cursor-col-resize")[0];
+        const rect = handle.getBoundingClientRect();
+
+        return { width: rect.width, root: parseFloat(getComputedStyle(document.documentElement).fontSize) };
+    }');
+
+    $data = is_array($result) && isset($result[0]) ? $result[0] : $result;
+
+    // Eight pixels is what the platforms settle on for a border a pointer has
+    // to catch, and it still fits inside the cell padding, so it never covers a
+    // label.
+    expect($data['width'])->toBeGreaterThanOrEqual(8);
+});
+
+it('resizes even when the drag starts a few pixels off the border', function (): void {
+    $page = visitLivewire(WrappedResizablePostDataTable::class);
+
+    $page->wait(2);
+
+    $result = $page->script('() => {
+        const handle = document.querySelectorAll(".cursor-col-resize")[0];
+        const th = handle.closest("th");
+        const rect = th.getBoundingClientRect();
+
+        // Aimed six pixels short of the border, which is what a hand does.
+        const x = rect.right - 6;
+        const y = rect.top + rect.height / 2;
+        const target = document.elementFromPoint(x, y);
+        const before = th.offsetWidth;
+
+        target && target.dispatchEvent(new MouseEvent("mousedown", { clientX: x, clientY: y, bubbles: true }));
+        document.dispatchEvent(new MouseEvent("mousemove", { clientX: x + 120, clientY: y, bubbles: true }));
+        document.dispatchEvent(new MouseEvent("mouseup", { clientX: x + 120, clientY: y, bubbles: true }));
+
+        return {
+            topmost: target ? target.tagName + "." + (target.className || "") : null,
+            before,
+            after: th.offsetWidth,
+        };
+    }');
+
+    $data = is_array($result) && isset($result[0]) ? $result[0] : $result;
+
+    expect($data['after'])->toBeGreaterThan($data['before']);
+});

--- a/tests/Fixtures/Livewire/WrappedResizablePostDataTable.php
+++ b/tests/Fixtures/Livewire/WrappedResizablePostDataTable.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Fixtures\Livewire;
+
+use Livewire\Attributes\Layout;
+use TeamNiftyGmbH\DataTable\DataTable;
+use Tests\Fixtures\Models\Post;
+
+#[Layout('components.layouts.app')]
+class WrappedResizablePostDataTable extends DataTable
+{
+    public static bool $wrapColumnLabels = true;
+
+    public array $enabledCols = [
+        'title',
+        'content',
+        'price',
+        'is_published',
+        'created_at',
+    ];
+
+    public bool $isSelectable = true;
+
+    protected string $model = Post::class;
+
+    protected function isResizable(): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
## Problem

The resize handle on a column header was `w-1`, four CSS pixels wide. In an application whose root font size is 14px it measures 3.5px, and users reading wide lists at 50–70% browser zoom get under two device pixels of grab area. That is not a small target, it is one a pointer cannot reliably hit, so the drag reads as a feature that is not there rather than one that keeps being missed.

## Change

The grab area is now `w-2.5`, ten pixels.

It deliberately stays inside the cell rather than straddling the column border. A column with a pinned width has `overflow-hidden` on its head cell, so anything hanging over the edge would be clipped. Ten pixels still fall entirely within the cell's `px-3` right padding, so no label is ever covered.

`w-2.5` and `hover:bg-primary-400` are already emitted by the host application's stylesheet. This matters: flux registers only this package's JavaScript (`resources/js/tall-datatables.js`), never its CSS, so a newly invented utility class in these views would render unstyled until the host application is rebuilt and released.

## Tests

Three browser tests, the first two red before the change:

- the grab area is at least eight pixels, the platform convention for a border a pointer has to catch
- a drag that starts six pixels short of the border still resizes, which is what a hand actually does
- a column can be dragged a second time once a width is stored, since that is the point where the table switches to a fixed layout and starts clipping its head cells

Full suite green: 2230 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)