### PR TITLE
Fetch only the key column when resolving a wildcard selection

### DIFF
--- a/src/Traits/DataTables/SupportsSelecting.php
+++ b/src/Traits/DataTables/SupportsSelecting.php
@@ -40,9 +40,17 @@ trait SupportsSelecting
 
     public function getSelectedValues(): array
     {
+        // Narrow the query down to the key column before plucking. buildSearch() leaves a full
+        // select list (and possibly withCount subselects) on the builder, and pluck() keeps an
+        // existing select list instead of replacing it, so every column of every matching row
+        // would be fetched. On large result sets that exhausts memory. Ordering is dropped for
+        // the same reason: it is meaningless for a list of keys and may reference a select alias
+        // that no longer exists.
         return in_array('*', $this->selected)
             ? $this->buildSearch(unpaginated: true)
                 ->whereKeyNot($this->wildcardSelectExcluded)
+                ->select($this->modelTable . '.' . $this->modelKeyName)
+                ->reorder()
                 ->pluck($this->modelKeyName)
                 ->toArray()
             : $this->selected;

--- a/tests/Feature/WildcardSelectQueryTest.php
+++ b/tests/Feature/WildcardSelectQueryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+use Tests\Fixtures\Livewire\PostDataTable;
+
+beforeEach(function (): void {
+    $this->user = createTestUser();
+    $this->actingAs($this->user);
+});
+
+it('only selects the key column when resolving a wildcard selection', function (): void {
+    createTestPost(['user_id' => $this->user->getKey()]);
+
+    $component = Livewire::test(PostDataTable::class)
+        ->set('selected', ['*'])
+        ->call('loadData');
+
+    $queries = [];
+    DB::listen(function ($query) use (&$queries): void {
+        $queries[] = $query->sql;
+    });
+
+    $component->instance()->getSelectedValues();
+
+    $select = collect($queries)
+        ->first(fn (string $sql): bool => str_contains($sql, 'from "posts"'));
+
+    expect($select)->not->toBeNull()
+        ->and($select)->toStartWith('select "posts"."id" from');
+});
+
+it('resolves a wildcard selection while ordering by an aggregate count column', function (): void {
+    $post = createTestPost(['user_id' => $this->user->getKey()]);
+
+    $component = Livewire::test(PostDataTable::class)
+        ->set('enabledCols', ['title', 'comments_count'])
+        ->set('userOrderBy', 'comments_count')
+        ->set('selected', ['*'])
+        ->call('loadData');
+
+    expect($component->instance()->getSelectedValues())->toBe([$post->getKey()]);
+});


### PR DESCRIPTION
## Problem

Selecting all rows and running a bulk action on a large filtered result set crashes with `Allowed memory size exhausted`.

`getSelectedValues()` builds the full data-table query via `buildSearch()` and then calls `pluck($modelKeyName)`. `buildSearch()` sets an explicit select list (all enabled columns, plus `withCount` subselects), and `Query\Builder::pluck()` only falls back to the passed column when no select list is present (`$this->columns ??= [$column]`). The existing select list therefore survives, and every column of every matching row is fetched just to extract the ids.

## Fix

Narrow the query to the key column before plucking, and drop the ordering. Ordering is meaningless for a list of keys and may reference a select alias (e.g. an aggregate `*_count`) that no longer exists once the select list is replaced.

## Tests

`tests/Feature/WildcardSelectQueryTest.php`

- the resolve query selects only the key column (fails without the fix)
- resolving still works while ordering by an aggregate count column (guards the `reorder()`)

Full suite green except the two `AssetControllerTest` cases that also fail on a clean `main` because the built assets are not present locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)