### PR TITLE
Decode html entities when exporting

### DIFF
--- a/src/Exports/Concerns/ExportsData.php
+++ b/src/Exports/Concerns/ExportsData.php
@@ -61,7 +61,7 @@ trait ExportsData
 
             if (! is_null($value) && $formatter) {
                 $value = is_array($value)
-                    ? strip_tags($formatter->format($value, $rowArray))
+                    ? $this->toPlainText($formatter->format($value, $rowArray))
                     : $this->formatExportValue($value, $formatter, $rowArray);
             }
 
@@ -124,6 +124,16 @@ trait ExportsData
             return $value ? __('Yes') : __('No');
         }
 
-        return strip_tags($formatter->format($value, $context));
+        return $this->toPlainText($formatter->format($value, $context));
+    }
+
+    /**
+     * Formatters escape their output for html. An exported cell is plain text, so the entities
+     * have to be turned back into the characters the user actually typed. Tags are stripped
+     * first, otherwise decoding would reintroduce markup that was deliberately escaped.
+     */
+    protected function toPlainText(string $value): string
+    {
+        return html_entity_decode(strip_tags($value), ENT_QUOTES | ENT_HTML5);
     }
 }

--- a/tests/Feature/ExportEntityDecodingTest.php
+++ b/tests/Feature/ExportEntityDecodingTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use TeamNiftyGmbH\DataTable\Exports\Concerns\ExportsData;
+use TeamNiftyGmbH\DataTable\Formatters\ArrayFormatter;
+use TeamNiftyGmbH\DataTable\Formatters\StringFormatter;
+
+beforeEach(function (): void {
+    $this->user = createTestUser();
+    $this->actingAs($this->user);
+
+    $this->exporter = fn (array $columns, array $formatters) => new class($columns, $formatters)
+    {
+        use ExportsData;
+
+        public function __construct(array $columns, array $formatters)
+        {
+            $this->exportColumns = $columns;
+            $this->exportFormatters = $formatters;
+        }
+    };
+});
+
+it('writes ampersands and quotes as themselves, not as html entities', function (): void {
+    $post = createTestPost([
+        'user_id' => $this->user->getKey(),
+        'title' => 'Ben & Jerry\'s "Special"',
+    ]);
+
+    $exporter = ($this->exporter)(['title'], ['title' => new StringFormatter()]);
+
+    expect($exporter->mapRow($post)['title'])->toBe('Ben & Jerry\'s "Special"');
+});
+
+it('writes plain characters for values behind an array formatter', function (): void {
+    $post = createTestPost([
+        'user_id' => $this->user->getKey(),
+        'title' => 'Ben & Jerry\'s',
+    ]);
+
+    $exporter = ($this->exporter)(
+        ['title'],
+        ['title' => new ArrayFormatter(new StringFormatter())]
+    );
+
+    expect($exporter->mapRow($post)['title'])->toBe('Ben & Jerry\'s');
+});
+
+it('still strips html tags', function (): void {
+    $post = createTestPost([
+        'user_id' => $this->user->getKey(),
+        'title' => '<b>bold</b> & plain',
+    ]);
+
+    $exporter = ($this->exporter)(['title'], ['title' => new StringFormatter()]);
+
+    expect($exporter->mapRow($post)['title'])->toBe('bold & plain');
+});


### PR DESCRIPTION
## Problem

Exported files contain html entities instead of the characters the user typed: `&` arrives as `&amp;`, `"` as `&quot;` and `'` as `&#039;`. Every export needs a find and replace pass in the spreadsheet afterwards.

`StringFormatter` (and the other formatters) escape their output with `e()` because they render into html. `ExportsData` only ran `strip_tags()` over that, which removes markup but leaves the entities untouched.

## Fix

A single `toPlainText()` helper strips the tags and then decodes the entities, used by both formatting paths in the trait. Order matters: decoding first would turn deliberately escaped markup back into tags that `strip_tags()` would then remove, silently losing content.

All three exporters (`DataTableExport`, `CsvExport`, `JsonExport`) share the trait, so they are all covered.

## Tests

`tests/Feature/ExportEntityDecodingTest.php`, three cases: plain formatter, array formatter, and a guard that tags are still stripped. All three fail without the fix.

Full suite green except the two `AssetControllerTest` cases that also fail on a clean `main` because the built assets are not present locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)