### PR TITLE
Alias joined tables that a query already reaches

### DIFF
--- a/src/Traits/DataTables/SupportsRelations.php
+++ b/src/Traits/DataTables/SupportsRelations.php
@@ -197,7 +197,20 @@ trait SupportsRelations
         // Start with the columns from the main model
         $selects = [$model->getTable() . '.*'];
 
+        // every table the query already reaches, so a hop that lands on one of them
+        // gets an alias instead of joining the same name twice. Joins from earlier
+        // calls count too, a multi sort walks this method once per column
+        $usedTables = [$model->getTable()];
+        foreach ($query->getQuery()->joins ?? [] as $join) {
+            if (is_string($join->table)) {
+                $usedTables[] = Str::contains($join->table, ' as ')
+                    ? Str::afterLast($join->table, ' as ')
+                    : $join->table;
+            }
+        }
+
         $relatedTable = null;
+        $parentTable = $model->getTable();
         foreach ($relationParts as $relationName) {
             $relationName = Str::camel($relationName);
 
@@ -212,27 +225,31 @@ trait SupportsRelations
             }
 
             $relatedModel = $relation->getRelated();
-            $relatedTable = $relatedModel->getTable();
-            $parentTable = $model->getTable();
+            $relatedTable = $this->uniqueJoinAlias($relatedModel->getTable(), $usedTables);
+            $joinTarget = $relatedTable === $relatedModel->getTable()
+                ? $relatedTable
+                : $relatedModel->getTable() . ' as ' . $relatedTable;
 
             if (method_exists($relation, 'getForeignKeyName') && method_exists($relation, 'getOwnerKeyName')) {
                 // For belongsTo relationships
                 $foreignKey = $relation->getForeignKeyName();
                 $ownerKey = $relation->getOwnerKeyName();
-                $query->join($relatedTable, "$parentTable.$foreignKey", '=', "$relatedTable.$ownerKey");
+                $query->join($joinTarget, "$parentTable.$foreignKey", '=', "$relatedTable.$ownerKey");
             } elseif (method_exists($relation, 'getForeignKey') && method_exists($relation, 'getLocalKeyName')) {
                 // For hasOne and hasMany relationships
                 $foreignKey = $relation->getForeignKey();
                 $localKey = $relation->getLocalKeyName();
-                $query->join($relatedTable, "$relatedTable.$foreignKey", '=', "$parentTable.$localKey");
+                $query->join($joinTarget, "$relatedTable.$foreignKey", '=', "$parentTable.$localKey");
             } else {
                 return $model->getTable();
             }
 
             $selects[] = "$relatedTable.*";
+            $usedTables[] = $relatedTable;
 
             // Update the model to the next relation's model
             $model = $relatedModel;
+            $parentTable = $relatedTable;
         }
 
         // Add any additional selects specified by the user
@@ -617,5 +634,33 @@ trait SupportsRelations
         }
 
         return $modelRelations;
+    }
+
+    /**
+     * A relation hop that lands on a table the query already joined needs its own
+     * alias, otherwise the same name appears twice and the database rejects the
+     * statement. A self referencing relation such as a category pointing at its
+     * parent is the common case.
+     *
+     * @param  array<int, string>  $usedTables
+     */
+    protected function uniqueJoinAlias(string $table, array $usedTables): string
+    {
+        if (! in_array($table, $usedTables, true)) {
+            return $table;
+        }
+
+        $suffix = 2;
+        while (in_array($table . '_' . $suffix, $usedTables, true)) {
+            $suffix++;
+        }
+
+        $alias = $table . '_' . $suffix;
+
+        // identifiers are capped at 64 characters, a long relation path would be cut
+        // off and could collide with another hop
+        return strlen($alias) > 64
+            ? 'tdt_' . substr(md5($alias), 0, 16) . '_' . $suffix
+            : $alias;
     }
 }

--- a/tests/Feature/SupportsRelationsTest.php
+++ b/tests/Feature/SupportsRelationsTest.php
@@ -1173,6 +1173,81 @@ describe('addDynamicJoin', function (): void {
             ->toThrow(Exception::class, "Relation 'nonExistent' is not defined");
     });
 
+    it('aliases a self referencing relation instead of joining the same table twice', function (): void {
+        $parent = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Parent Post']);
+        createTestPost([
+            'user_id' => $this->user->getKey(),
+            'title' => 'Child Post',
+            'parent_id' => $parent->getKey(),
+        ]);
+
+        $component = Livewire::test(PostWithRelationsDataTable::class);
+        $instance = $component->instance();
+
+        $query = Post::query();
+        $method = new ReflectionMethod($instance, 'addDynamicJoin');
+        // the joined table selects its own columns too, so the child title is read
+        // through a select of its own instead of the clobbered title column
+        $relatedTable = $method->invoke($instance, $query, 'parent', ['posts.title as child_title']);
+
+        // the hop lands on posts again, so it needs a name of its own
+        expect($relatedTable)->not->toBe('posts');
+
+        // without the alias the database rejects this with
+        // "1066 Not unique table/alias: 'posts'"
+        $results = $query->orderBy($relatedTable . '.title')->get();
+
+        expect($results)->toHaveCount(1)
+            ->and($results->first()->child_title)->toBe('Child Post');
+    });
+
+    it('aliases every hop of a path that walks the same table twice', function (): void {
+        $grandparent = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Grandparent']);
+        $parent = createTestPost([
+            'user_id' => $this->user->getKey(),
+            'title' => 'Parent',
+            'parent_id' => $grandparent->getKey(),
+        ]);
+        createTestPost([
+            'user_id' => $this->user->getKey(),
+            'title' => 'Child',
+            'parent_id' => $parent->getKey(),
+        ]);
+
+        $component = Livewire::test(PostWithRelationsDataTable::class);
+        $instance = $component->instance();
+
+        $query = Post::query();
+        $method = new ReflectionMethod($instance, 'addDynamicJoin');
+        $relatedTable = $method->invoke($instance, $query, 'parent.parent', ['posts.title as child_title']);
+
+        $results = $query->orderBy($relatedTable . '.title')->get();
+
+        expect($results)->toHaveCount(1)
+            ->and($results->first()->child_title)->toBe('Child');
+    });
+
+    it('aliases a second join of the same table on one query, as a multi sort does', function (): void {
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Multi Sort Post']);
+
+        $component = Livewire::test(PostWithRelationsDataTable::class);
+        $instance = $component->instance();
+
+        $query = Post::query();
+        $method = new ReflectionMethod($instance, 'addDynamicJoin');
+
+        $first = $method->invoke($instance, $query, 'user');
+        $second = $method->invoke($instance, $query, 'user');
+
+        expect($first)->toBe('users')
+            ->and($second)->not->toBe('users');
+
+        // each sorted column walks addDynamicJoin once, so the second pass must not
+        // reuse the name the first pass already occupies
+        expect($query->orderBy($first . '.name')->orderBy($second . '.email')->get())
+            ->toHaveCount(1);
+    });
+
     it('adds additional selects when specified', function (): void {
         createTestPost(['user_id' => $this->user->getKey()]);
 

--- a/tests/Fixtures/Models/Post.php
+++ b/tests/Fixtures/Models/Post.php
@@ -49,6 +49,11 @@ class Post extends Model implements InteractsWithDataTables
         return '/posts/' . $this->getKey();
     }
 
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_id');
+    }
+
     public function tags(): MorphToMany
     {
         return $this->morphToMany(Tag::class, 'taggable');

--- a/tests/database/migrations/0001_01_01_000001_create_posts_table.php
+++ b/tests/database/migrations/0001_01_01_000001_create_posts_table.php
@@ -11,6 +11,7 @@ return new class() extends Migration
         Schema::create('posts', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('parent_id')->nullable()->constrained('posts')->nullOnDelete();
             $table->string('title');
             $table->text('content')->nullable();
             $table->decimal('price', 10, 2)->nullable();


### PR DESCRIPTION
## Problem

Sorting by a column behind a self referencing relation aborts the query. Reproduced in a live instance by enabling the parent category column on a task list and clicking its header:

```
SQLSTATE[42000]: Syntax error or access violation: 1066 Not unique table/alias: 'categories'
SQL: select count(*) as `aggregate` from `tasks`
       inner join `categories` on `tasks`.`sbm_category_id` = `categories`.`id`
       inner join `categories` on `categories`.`parent_id` = `categories`.`id`
     where `project_id` = 1868 and `tasks`.`deleted_at` is null
```

`addDynamicJoin()` joined every relation hop under its plain table name. A hop that lands on a table the query already reaches therefore repeated that name, which the database rejects, and the `ON` clause compared the table against itself.

The table shows "no data found" and the user gets a raw SQL error. Any customer with a category hierarchy is affected, not just the one this was found on.

## Change

Each hop takes an alias when its table is already in use. The `ON` clause and the following hop reference that alias, and the alias is returned so the caller orders by the right table.

Tables joined by **earlier calls** count as in use as well: `applySorting()` walks `applyOrderBy()` once per sorted column, so a multi sort across two paths that touch the same table hits the same defect. Without that, only the reported click would be healed while the multi sort stayed broken.

A hop whose table is still free keeps its plain name, so single hop paths return the table exactly as before and existing expectations (`'users'` for a `BelongsTo`) stay valid.

## Tests

Three cases in the `addDynamicJoin` block, each aborting with a `QueryException` before the change:

| Test | Covers |
|---|---|
| aliases a self referencing relation instead of joining the same table twice | `parent` on the same table |
| aliases every hop of a path that walks the same table twice | `parent.parent` |
| aliases a second join of the same table on one query, as a multi sort does | two calls on one query |

The fixtures gain a self referencing `parent` relation on `Post` and a nullable `parent_id` column, since no fixture had one.

Verified against the unchanged source: with the fix reverted, all three fail.

Suite: Unit and Feature, 2114 passed, 15 skipped. Two failures in `AssetControllerTest` are pre-existing and fail identically without this change (built assets missing in the working copy). Browser suite skipped, Playwright is not installed locally. Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012U7EKCjdm81QGFqUgQQupd