### PR TITLE
Only take a horizontal scroll port when the table needs one

### DIFF
--- a/resources/views/components/layouts/table.blade.php
+++ b/resources/views/components/layouts/table.blade.php
@@ -23,7 +23,25 @@
     class="mt-3 flex flex-col"
     x-data="{ showSelectedActions: false }"
 >
-    <div class="relative overflow-x-auto shadow-sm sm:rounded-lg">
+    {{--
+        `overflow-x: auto` makes this div the scroll port for the sticky head
+        cells, and CSS forces `overflow-y` to `auto` along with it. The div is
+        never height bounded, so it has nothing to scroll vertically and
+        `top: 0` has nothing to stick to: the head scrolls off with the page.
+
+        A table that fits does not need the scroll port at all, so only take it
+        when the table is actually wider than the wrapper.
+    --}}
+    <div
+        class="relative shadow-sm sm:rounded-lg"
+        x-data="{ overflows: false }"
+        x-init="
+            const measure = () => overflows = $el.scrollWidth > $el.clientWidth;
+            measure();
+            new ResizeObserver(measure).observe($el);
+        "
+        x-bind:class="overflows && 'overflow-x-auto'"
+    >
         <table class="dark:bg-secondary-800 min-w-full border-collapse bg-white text-sm text-gray-500 dark:text-gray-50"
             x-bind:class="Object.keys($wire.colWidths || {}).length > 0 ? 'table-fixed' : 'table-auto'"
         >

--- a/tests/Browser/StickyHeadBrowserTest.php
+++ b/tests/Browser/StickyHeadBrowserTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Browser Tests for the sticky column head
+ *
+ * The head cells carry `sticky top-0`, but whether that sticks depends on which
+ * box scrolls. Only a real browser resolves that, so this cannot be asserted
+ * server side.
+ */
+
+use Tests\Fixtures\Livewire\TallPostDataTable;
+
+beforeEach(function (): void {
+    $manifestPath = dirname(__DIR__, 2) . '/dist/build/manifest.json';
+    if (! file_exists($manifestPath)) {
+        $this->markTestSkipped('Browser tests require built assets. Run: npm run build');
+    }
+
+    $this->user = createTestUser(['name' => 'Test User', 'email' => 'sticky-head@example.com']);
+
+    foreach (range(1, 60) as $i) {
+        createTestPost([
+            'user_id' => $this->user->getKey(),
+            'title' => 'Post Title ' . $i,
+            'content' => 'Content ' . $i,
+            'is_published' => true,
+        ]);
+    }
+});
+
+describe('Sticky column head', function (): void {
+    it('keeps the head cells on screen while the page scrolls', function (): void {
+        $page = visitLivewire(TallPostDataTable::class);
+
+        $page->wait(3);
+
+        $result = $page->script('async () => {
+            const th = [...document.querySelectorAll("thead th")]
+                .find(el => getComputedStyle(el).position === "sticky");
+
+            if (! th) {
+                return {error: "no-sticky-head-cell"};
+            }
+
+            const style = getComputedStyle(th);
+            const before = th.getBoundingClientRect().top;
+
+            window.scrollTo(0, 800);
+            await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+
+            return {
+                position: style.position,
+                top: style.top,
+                documentScrolled: window.scrollY,
+                headTopBefore: before,
+                headTopAfter: th.getBoundingClientRect().top,
+                docScrollable: document.documentElement.scrollHeight > window.innerHeight,
+            };
+        }');
+
+        $data = is_array($result) ? ($result[0] ?? $result) : $result;
+
+        expect($data['position'])->toBe('sticky');
+        expect($data['documentScrolled'])->toBeGreaterThan(0);
+        expect($data['headTopAfter'])->toBeGreaterThanOrEqual(0);
+    });
+
+    it('still scrolls a table that is wider than the screen', function (): void {
+        $page = visitLivewire(TallPostDataTable::class)->on()->mobile();
+
+        $page->wait(3);
+
+        $result = $page->script('async () => {
+            const wrapper = document.querySelector("table").parentElement;
+
+            wrapper.scrollLeft = 200;
+            await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+
+            return {
+                overflowX: getComputedStyle(wrapper).overflowX,
+                scrolledLeft: wrapper.scrollLeft,
+                wider: wrapper.scrollWidth > wrapper.clientWidth,
+            };
+        }');
+
+        $data = is_array($result) ? ($result[0] ?? $result) : $result;
+
+        expect($data['wider'])->toBeTrue();
+        expect($data['overflowX'])->toBe('auto');
+        expect($data['scrolledLeft'])->toBeGreaterThan(0);
+    });
+});

--- a/tests/Fixtures/Livewire/TallPostDataTable.php
+++ b/tests/Fixtures/Livewire/TallPostDataTable.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Fixtures\Livewire;
+
+use Livewire\Attributes\Layout;
+use TeamNiftyGmbH\DataTable\DataTable;
+use Tests\Fixtures\Models\Post;
+
+#[Layout('components.layouts.app')]
+class TallPostDataTable extends DataTable
+{
+    public array $enabledCols = [
+        'title',
+        'content',
+    ];
+
+    // Enough rows that the page itself scrolls, which is what a sticky head needs.
+    public int $perPage = 50;
+
+    protected string $model = Post::class;
+}


### PR DESCRIPTION
The head cells carry `sticky top-0`, but the wrapper around the table carries `overflow-x-auto`, and CSS forces `overflow-y` to `auto` alongside it. That makes the wrapper the scroll port the head sticks to. The wrapper is never height bounded, so it has nothing to scroll vertically and `top: 0` has nothing to stick to: the head scrolls off with the page.

Measured in the browser, scrolling the page 800px:

| wrapper overflow | computed | head cell top |
| --- | --- | --- |
| `overflow-x-auto` (before) | `auto/auto` | -788 |
| `overflow-y: visible` | `auto/auto` | -788 |
| `overflow-y: clip` | `auto/hidden` | -788 |
| both `visible` | `visible/visible` | 0 |

`overflow-y` cannot be given back on its own, the computed value returns to `auto` as long as the other axis scrolls. That is also why `border-collapse: separate` changes nothing here: the scroll port is what breaks it, not the table.

A table that fits needs no scroll port at all. Its `scrollWidth` equals its `clientWidth`, so the wrapper never scrolls horizontally either and only costs the sticky head. So take the scroll port only while the table is actually wider than the wrapper, measured with a `ResizeObserver`.

Nothing changes visually or in handling. A table that fits scrolls with the page exactly as before and now keeps its head on screen, and a table that is too wide keeps its horizontal scrolling.

Both are covered by browser tests: the head stays at `top >= 0` after an 800px page scroll, and a table wider than the viewport still takes `overflow-x: auto` and still scrolls sideways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbDZzptKgKQKa1XNir5W5f