### PR TITLE
Resolve dynamic relations up the class hierarchy

### DIFF
--- a/src/Helpers/RelationFinder.php
+++ b/src/Helpers/RelationFinder.php
@@ -35,8 +35,21 @@ class RelationFinder
         $class = new ReflectionClass($model);
         $relationResolvers = $class->getProperty('relationResolvers');
 
+        // Eloquent resolves a dynamic relation up the parent chain, so a look up
+        // has to walk the same way: a package registers the relation on the core
+        // model while the container hands out a customised subclass. Whatever the
+        // child registers wins, an override must not be hidden by its parent.
+        $resolvers = $relationResolvers->getValue($model);
+        $resolved = [];
+
+        for ($current = get_class($model); $current; $current = get_parent_class($current)) {
+            foreach (data_get($resolvers, $current, []) as $relationName => $closure) {
+                $resolved[$relationName] ??= $closure;
+            }
+        }
+
         $relations = [];
-        foreach (data_get($relationResolvers->getValue($model), get_class($model), []) as $relationName => $closure) {
+        foreach ($resolved as $relationName => $closure) {
             try {
                 $relation = $closure($model);
                 $relations[] = new Relation(

--- a/tests/Fixtures/Models/ExtendedPost.php
+++ b/tests/Fixtures/Models/ExtendedPost.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests\Fixtures\Models;
+
+/**
+ * A subclass bound over its base class in the container, which is how a
+ * customised core model reaches a data table.
+ */
+class ExtendedPost extends Post
+{
+    protected $table = 'posts';
+}

--- a/tests/Unit/Helpers/RelationFinderTest.php
+++ b/tests/Unit/Helpers/RelationFinderTest.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Support\Collection;
 use TeamNiftyGmbH\DataTable\Helpers\RelationFinder;
+use Tests\Fixtures\Models\Comment;
+use Tests\Fixtures\Models\ExtendedPost;
 use Tests\Fixtures\Models\Post;
 use Tests\Fixtures\Models\User;
 
@@ -80,7 +82,7 @@ describe('RelationFinder', function (): void {
         });
 
         it('includes relations on Comment model', function (): void {
-            $relations = RelationFinder::forModel(new Tests\Fixtures\Models\Comment());
+            $relations = RelationFinder::forModel(new Comment());
 
             expect($relations)->toBeInstanceOf(Collection::class);
             $names = $relations->pluck('name')->toArray();
@@ -114,7 +116,7 @@ describe('RelationFinder', function (): void {
         });
 
         it('handles model with no relation resolvers', function (): void {
-            $relations = RelationFinder::forModel(new Tests\Fixtures\Models\Comment());
+            $relations = RelationFinder::forModel(new Comment());
 
             expect($relations)->toBeInstanceOf(Collection::class)
                 ->not->toBeEmpty();
@@ -149,6 +151,34 @@ describe('RelationFinder', function (): void {
             $names = $relations->pluck('name')->toArray();
 
             expect($names)->toContain('dynamicRelation');
+        });
+
+        it('discovers a dynamic relation registered on a parent class', function (): void {
+            // A package registers on the core model, the container hands out the subclass.
+            Post::resolveRelationUsing('inheritedDynamicRelation', function ($model) {
+                return $model->belongsTo(User::class, 'user_id');
+            });
+
+            $relations = RelationFinder::forModel(new ExtendedPost());
+            $names = $relations->pluck('name')->toArray();
+
+            expect($names)->toContain('inheritedDynamicRelation');
+        });
+
+        it('lets the child class win over a relation of the same name on the parent', function (): void {
+            Post::resolveRelationUsing('overriddenDynamicRelation', function ($model) {
+                return $model->belongsTo(User::class, 'user_id');
+            });
+
+            ExtendedPost::resolveRelationUsing('overriddenDynamicRelation', function ($model) {
+                return $model->hasMany(Comment::class, 'post_id');
+            });
+
+            $relation = RelationFinder::forModel(new ExtendedPost())
+                ->firstWhere('name', 'overriddenDynamicRelation');
+
+            expect($relation)->not->toBeNull()
+                ->and($relation->related)->toBe(Comment::class);
         });
 
         it('filters out null results from methods that throw exceptions', function (): void {


### PR DESCRIPTION
`RelationFinder::relations()` read the dynamic relation resolvers under the exact instance class only. Eloquent itself does not: `relationResolver()` walks up the parent chain, which is why `isRelation()` and calling the relation both work fine for a relation registered on a parent.

That gap shows whenever a customised model is bound over a core model in the container, which is the normal case here. A package registers its relation on the core class, the container hands out the subclass, and the relation resolves at runtime but never appears in the column picker or under relations:

```
relationResolvers['FluxErp\Models\Address'] => mailingLists, unsubscribedMailingLists
relationResolvers['App\Models\Address']     => geoLocationResult
the instance is                             => App\Models\Address
```

Now the lookup walks the same chain, and whatever the child registers wins so an override is not hidden by its parent.

Two tests cover it: a relation registered on the parent is found on the subclass, and a relation registered under the same name on both resolves to the child's.