### PR TITLE
Share one subquery between OR conditions on the same relation column

### DIFF
--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -139,8 +139,22 @@ trait BuildsQueries
                 } else {
                     try {
                         $query->whereHas($filter['relation'], function (Builder $subQuery) use ($type, $filter) {
+                            $values = $this->foldedFilterValues($filter);
                             unset($filter['relation']);
-                            $this->addFilter($subQuery, $type, $filter);
+
+                            if ($values === null) {
+                                $this->addFilter($subQuery, $type, $filter);
+
+                                return $subQuery;
+                            }
+
+                            $subQuery->where(function (Builder $anyValue) use ($type, $filter, $values): void {
+                                foreach ($values as $value) {
+                                    $anyValue->orWhere(function (Builder $oneValue) use ($type, $filter, $value): void {
+                                        $this->addFilter($oneValue, $type, ['value' => $value] + $filter);
+                                    });
+                                }
+                            });
 
                             return $subQuery;
                         });
@@ -850,9 +864,6 @@ trait BuildsQueries
         });
     }
 
-    /**
-     * Apply fixed and user filters to the query.
-     */
     private function applyFilters(Builder $builder): Builder
     {
         // add fixed filters
@@ -877,7 +888,9 @@ trait BuildsQueries
         // Filters within a group are AND, groups are OR with each other
         if (! empty($this->userFilters)) {
             // Migrate old format if needed
-            $filters = $this->migrateFilterFormat($this->userFilters);
+            $filters = $this->collapseOrGroupsOnSameRelationColumn(
+                $this->migrateFilterFormat($this->userFilters)
+            );
 
             $builder->where(function ($query) use ($filters): void {
                 foreach (array_values($filters) as $index => $orFilter) {
@@ -1022,6 +1035,87 @@ trait BuildsQueries
                 $this->applyOrderBy($query, $sort['column'], $sort['asc']);
             }
         }
+    }
+
+    /**
+     * Apply fixed and user filters to the query.
+     */
+    /**
+     * A saved filter that asks for many values of the same relation column arrives as one
+     * OR group per value, and every group turns into its own EXISTS subquery over the whole
+     * table. Since they all test the same column the same way, one subquery accepting any
+     * of the values gives the same rows for a fraction of the work.
+     *
+     * Only positive tests may be folded. "not A" OR "not B" is not "not in (A, B)", and the
+     * relation wildcards have no value to collect, so those groups are left alone.
+     *
+     * @param  array<int, mixed>  $filters
+     * @return array<int, mixed>
+     */
+    private function collapseOrGroupsOnSameRelationColumn(array $filters): array
+    {
+        $collapsed = [];
+        $seen = [];
+
+        foreach (array_values($filters) as $group) {
+            $condition = is_array($group) && count($group) === 1 ? reset($group) : null;
+
+            if (
+                ! is_array($condition)
+                || ! is_string($condition['column'] ?? null)
+                || ! str_contains($condition['column'], '.')
+                || ! in_array($condition['operator'] ?? null, $this->foldableFilterOperators(), true)
+                || ! is_scalar($condition['value'] ?? null)
+                || in_array($condition['value'], ['%*%', '%!*%'], true)
+            ) {
+                $collapsed[] = $group;
+
+                continue;
+            }
+
+            $key = $condition['column'] . "\0" . $condition['operator'];
+
+            if (! isset($seen[$key])) {
+                $seen[$key] = count($collapsed);
+                $condition['value'] = [$condition['value']];
+                $collapsed[] = [$condition];
+
+                continue;
+            }
+
+            $existing = reset($collapsed[$seen[$key]]);
+            $existing['value'][] = $condition['value'];
+            $collapsed[$seen[$key]] = [$existing];
+        }
+
+        return $collapsed;
+    }
+
+    /**
+     * Operators whose OR conditions on one relation column may share a single subquery.
+     * Every one of them is a positive test, so "A or B" is the same as testing for both
+     * inside one subquery. A negated operator must not be folded: "not A" or "not B" is
+     * not "neither A nor B".
+     *
+     * @return array<int, string>
+     */
+    private function foldableFilterOperators(): array
+    {
+        return ['=', 'like', 'contains', 'starts with', 'ends with'];
+    }
+
+    /**
+     * The values a folded condition carries, or null for an ordinary single valued one.
+     *
+     * @param  array<string, mixed>  $filter
+     * @return array<int, mixed>|null
+     */
+    private function foldedFilterValues(array $filter): ?array
+    {
+        return in_array($filter['operator'] ?? null, $this->foldableFilterOperators(), true)
+            && is_array($filter['value'] ?? null)
+                ? array_values($filter['value'])
+                : null;
     }
 
     /**

--- a/tests/Feature/OrFilterCollapseTest.php
+++ b/tests/Feature/OrFilterCollapseTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+use Tests\Fixtures\Livewire\PostDataTable;
+use Tests\Fixtures\Models\Tag;
+
+beforeEach(function (): void {
+    $this->user = createTestUser();
+    $this->actingAs($this->user);
+});
+
+describe('OR conditions on the same relation column', function (): void {
+    it('folds them into a single subquery', function (): void {
+        foreach (['Alpha', 'Beta', 'Gamma', 'Delta'] as $name) {
+            Tag::create(['name' => $name]);
+        }
+
+        $queries = [];
+        DB::listen(function ($query) use (&$queries): void {
+            $queries[] = $query->sql;
+        });
+
+        Livewire::test(PostDataTable::class)
+            ->set('enabledCols', ['title'])
+            ->set('userFilters', [
+                [['column' => 'tags.name', 'operator' => '=', 'value' => 'Alpha']],
+                [['column' => 'tags.name', 'operator' => '=', 'value' => 'Beta']],
+                [['column' => 'tags.name', 'operator' => '=', 'value' => 'Gamma']],
+            ])
+            ->call('loadData');
+
+        $select = collect($queries)->first(fn (string $sql) => str_contains($sql, 'exists'));
+
+        expect($select)->not->toBeNull()
+            ->and(substr_count($select, 'exists'))->toBe(1);
+    });
+
+    it('still matches every row that any of the values matches', function (): void {
+        $alpha = Tag::create(['name' => 'Alpha']);
+        $beta = Tag::create(['name' => 'Beta']);
+        $gamma = Tag::create(['name' => 'Gamma']);
+        $delta = Tag::create(['name' => 'Delta']);
+
+        $withAlpha = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Has Alpha']);
+        $withAlpha->tags()->attach($alpha);
+
+        $withBeta = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Has Beta']);
+        $withBeta->tags()->attach($beta);
+
+        $withGamma = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Has Gamma']);
+        $withGamma->tags()->attach($gamma);
+
+        $withDelta = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Has Delta']);
+        $withDelta->tags()->attach($delta);
+
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Has None']);
+
+        $component = Livewire::test(PostDataTable::class)
+            ->set('enabledCols', ['title'])
+            ->set('userFilters', [
+                [['column' => 'tags.name', 'operator' => '=', 'value' => 'Alpha']],
+                [['column' => 'tags.name', 'operator' => '=', 'value' => 'Beta']],
+                [['column' => 'tags.name', 'operator' => '=', 'value' => 'Gamma']],
+            ])
+            ->call('loadData');
+
+        $data = $component->instance()->getDataForTesting();
+        $titles = collect($data['data'])->pluck('title')->all();
+
+        expect($data['total'])->toBe(3)
+            ->and($titles)->toContain('Has Alpha')
+            ->and($titles)->toContain('Has Beta')
+            ->and($titles)->toContain('Has Gamma')
+            ->and($titles)->not->toContain('Has Delta')
+            ->and($titles)->not->toContain('Has None');
+    });
+
+    it('leaves a negated condition in its own subquery', function (): void {
+        $alpha = Tag::create(['name' => 'Alpha']);
+        $beta = Tag::create(['name' => 'Beta']);
+
+        $withAlpha = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Has Alpha']);
+        $withAlpha->tags()->attach($alpha);
+
+        $withBeta = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Has Beta']);
+        $withBeta->tags()->attach($beta);
+
+        createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Has None']);
+
+        // "not Alpha" OR "not Beta" is not the same as "not in (Alpha, Beta)",
+        // so these two must stay two subqueries.
+        $component = Livewire::test(PostDataTable::class)
+            ->set('enabledCols', ['title'])
+            ->set('userFilters', [
+                [['column' => 'tags.name', 'operator' => '!=', 'value' => 'Alpha']],
+                [['column' => 'tags.name', 'operator' => '!=', 'value' => 'Beta']],
+            ])
+            ->call('loadData');
+
+        $data = $component->instance()->getDataForTesting();
+        $titles = collect($data['data'])->pluck('title')->all();
+
+        expect($data['total'])->toBe(3)
+            ->and($titles)->toContain('Has Alpha')
+            ->and($titles)->toContain('Has Beta')
+            ->and($titles)->toContain('Has None');
+    });
+});


### PR DESCRIPTION
A saved filter that asks for many values of one relation column arrives as one OR group per value, and every group became its own `EXISTS` subquery over the whole table. A filter with 47 OR rows on the same column therefore ran 47 `EXISTS` over 210k addresses and hit the 30 second execution limit.

The rows all test the same column the same way, so they can share a single subquery that accepts any of the values. 47 `EXISTS` become one.

Only positive operators are folded: `=`, `like`, `contains`, `starts with` and `ends with`. A negated operator has to keep its own subquery, `not A` or `not B` is not `neither A nor B`, and the relation wildcards (`%*%`, `%!*%`) carry no value to collect. Groups holding more than one condition are left alone.

The values ride along in `value` as an array rather than in a key of their own, because `parseFilter()` keeps only `column`, `operator`, `value` and `relation`. That way they also get the same value normalisation a single value gets.

Nothing changes for the user, the same filter returns the same rows.

Three tests: the folded filter produces exactly one `exists`, it still matches every row any of the values matches, and two negated conditions keep their separate subqueries.