### PR TITLE
fix: keep eager loaded relations in the serialized row

### DIFF
--- a/src/Traits/DataTables/BuildsQueries.php
+++ b/src/Traits/DataTables/BuildsQueries.php
@@ -672,8 +672,12 @@ trait BuildsQueries
      *
      * Relations are serialized under their snake case name but filtered under the name
      * they were loaded with, so both spellings belong in the set.
+     *
+     * A relation that was eager loaded belongs in it too, even when no column names
+     * it: getBuilder() pulling in ->with('currency') is a statement that the row needs
+     * that relation, and formatters read it off the serialized array.
      */
-    protected function getSerializableKeys(): array
+    protected function getSerializableKeys(Model $item): array
     {
         $segments = array_map(
             fn (string $key): string => Str::before($key, '.'),
@@ -681,6 +685,7 @@ trait BuildsQueries
                 $this->getReturnKeys(),
                 $this->enabledCols,
                 $this->getAppends(),
+                array_keys($item->getRelations()),
                 Arr::flatten($this->getLeftAppends()),
                 Arr::flatten($this->getRightAppends()),
                 Arr::flatten($this->getTopAppends()),
@@ -702,7 +707,7 @@ trait BuildsQueries
         }
 
         $visible = $item->getVisible();
-        $item->setVisible($this->getSerializableKeys());
+        $item->setVisible($this->getSerializableKeys($item));
 
         $rawArray = $item->toArray();
 


### PR DESCRIPTION
Regression from #286, released as v2.6.11.

Restricting serialization to the keys a table asks for worked those keys out from the columns, the return keys and the appends. A relation that `getBuilder()` eager loads **without any column naming it** was not among them, so it fell out of the row.

That is not hypothetical. `FluxErp\Livewire\Order\OrderPositions` loads `->with('currency')` to format its money columns. Without the relation the formatter falls back to the default currency, so the positions of an order in USD render with euro signs.

| | v2.6.11 | with this change |
| --- | --- | --- |
| flux-core `money columns are formatted with order currency not default EUR` | fails | passes |

Eager loading a relation is a statement that the row needs it, so the loaded relation names now join the visible set. Attributes and relations nobody asked for stay out, which is where the saving came from.

The differential check behind #286 covered four production tables and found byte identical output. None of them eager loads a relation that no column names, which is why it missed this.