### PR TITLE
Render the options sidebar on first open

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "livewire/livewire": "^4.0",
         "phpoffice/phpspreadsheet": "^5.3",
         "spatie/laravel-model-info": "^1.0|^2.0",
-        "tallstackui/tallstackui": "^3.0"
+        "tallstackui/tallstackui": "^3.2.1"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/resources/views/components/layouts/grid.blade.php
+++ b/resources/views/components/layouts/grid.blade.php
@@ -69,6 +69,7 @@
                     color="secondary"
                     flat
                     sm
+                    loading="showSidebar"
                     icon="cog-6-tooth"
                     x-on:click="$wire.showSidebar().then(() => {$tsui.open.slide('data-table-sidebar-' + $wire.id.toLowerCase());})"
                 />

--- a/resources/views/components/layouts/grid.blade.php
+++ b/resources/views/components/layouts/grid.blade.php
@@ -70,7 +70,7 @@
                     flat
                     sm
                     icon="cog-6-tooth"
-                    x-on:click="$tsui.open.slide('data-table-sidebar-' + $wire.id.toLowerCase())"
+                    x-on:click="$wire.showSidebar().then(() => {$tsui.open.slide('data-table-sidebar-' + $wire.id.toLowerCase());})"
                 />
             @endif
         </div>

--- a/resources/views/components/layouts/kanban.blade.php
+++ b/resources/views/components/layouts/kanban.blade.php
@@ -72,7 +72,7 @@
                     flat
                     sm
                     icon="cog-6-tooth"
-                    x-on:click="$tsui.open.slide('data-table-sidebar-' + $wire.id.toLowerCase())"
+                    x-on:click="$wire.showSidebar().then(() => {$tsui.open.slide('data-table-sidebar-' + $wire.id.toLowerCase());})"
                 />
             @endif
         </div>

--- a/resources/views/components/layouts/kanban.blade.php
+++ b/resources/views/components/layouts/kanban.blade.php
@@ -71,6 +71,7 @@
                     color="secondary"
                     flat
                     sm
+                    loading="showSidebar"
                     icon="cog-6-tooth"
                     x-on:click="$wire.showSidebar().then(() => {$tsui.open.slide('data-table-sidebar-' + $wire.id.toLowerCase());})"
                 />

--- a/resources/views/components/layouts/kanban.blade.php
+++ b/resources/views/components/layouts/kanban.blade.php
@@ -94,7 +94,14 @@
             $modelKeyName = $this->modelKeyName;
             $enabledCols = $this->enabledCols;
             $records = $this->data['data'] ?? [];
-            $grouped = collect($records)->groupBy(fn ($record) => (string) (is_array($record[$kanbanColumn] ?? null) ? $record[$kanbanColumn]['raw'] ?? '' : $record[$kanbanColumn] ?? ''));
+            $grouped = collect($records)->groupBy(function ($record) use ($kanbanColumn) {
+                $value = is_array($record[$kanbanColumn] ?? null)
+                    ? $record[$kanbanColumn]['raw'] ?? ''
+                    : $record[$kanbanColumn] ?? '';
+
+                // a bool lane column casts to '' for false, which matches no lane
+                return is_bool($value) ? (string) (int) $value : (string) $value;
+            });
         @endphp
 
         @if (empty($records))

--- a/resources/views/components/layouts/partials/table-row.blade.php
+++ b/resources/views/components/layouts/partials/table-row.blade.php
@@ -66,14 +66,28 @@
             );
         @endphp
         {{-- bound through Alpine like the head and filter cells, so toggling a sticky column takes effect without a re-render --}}
-        <x-tall-datatables::table.cell
-            :use-wire-navigate="$useWireNavigate"
-            :data-column="$col"
-            :class="$cellAttrClasses"
-            x-bind:class="($wire.stickyCols || []).includes({{ \Illuminate\Support\Js::from($col) }}) ? 'sticky left-0 border-r bg-white dark:bg-secondary-800 dark:text-gray-50' : ''"
-            x-bind:style="($wire.stickyCols || []).includes({{ \Illuminate\Support\Js::from($col) }}) ? 'z-index: 2' : ''"
-            :href="(($allowSoftDeletes && ($record['deleted_at'] ?? null)) ? null : ($record['href'] ?? null))"
+        @php
+            $cellHref = ($allowSoftDeletes && ($record['deleted_at'] ?? null)) ? null : ($record['href'] ?? null);
+            $cellClasses = 'border-b border-gray-100 dark:border-secondary-700/50 text-sm p-0'
+                . (str_contains($cellAttrClasses, 'whitespace-') ? '' : ' whitespace-nowrap max-w-xs overflow-hidden text-ellipsis')
+                . ($cellAttrClasses === '' ? '' : ' ' . $cellAttrClasses);
+            $cellSticky = '($wire.stickyCols || []).includes(' . \Illuminate\Support\Js::from($col) . ')';
+        @endphp
+        <td
+            class="{{ $cellClasses }}"
+            data-column="{{ $col }}"
+            x-bind:class="{{ $cellSticky }} ? 'sticky left-0 border-r bg-white dark:bg-secondary-800 dark:text-gray-50' : ''"
+            x-bind:style="{{ $cellSticky }} ? 'z-index: 2' : ''"
         >
+            @if ($cellHref)
+                <a
+                    @if ($useWireNavigate) x-on:click.prevent="$el.href && Livewire.navigate($el.href)" @endif
+                    href="{{ $cellHref }}"
+                    class="block px-3 py-2.5"
+                >
+            @else
+                <div class="px-3 py-2.5">
+            @endif
             @php
                 $hasLeftAppend = isset($leftAppend[$col]);
                 $hasRightAppend = isset($rightAppend[$col]);
@@ -125,7 +139,12 @@
                     @endif
                 @endforeach
             @endif
-        </x-tall-datatables::table.cell>
+            @if ($cellHref)
+                </a>
+            @else
+                </div>
+            @endif
+        </td>
     @endforeach
     @if ($rowActions || ($showRestoreButton && $allowSoftDeletes))
         <td

--- a/resources/views/components/layouts/partials/table-row.blade.php
+++ b/resources/views/components/layouts/partials/table-row.blade.php
@@ -76,8 +76,8 @@
         <td
             class="{{ $cellClasses }}"
             data-column="{{ $col }}"
-            x-bind:class="{{ $cellSticky }} ? 'sticky left-0 border-r bg-white dark:bg-secondary-800 dark:text-gray-50' : ''"
-            x-bind:style="{{ $cellSticky }} ? 'z-index: 2' : ''"
+            x-bind:class="{!! $cellSticky !!} ? 'sticky left-0 border-r bg-white dark:bg-secondary-800 dark:text-gray-50' : ''"
+            x-bind:style="{!! $cellSticky !!} ? 'z-index: 2' : ''"
         >
             @if ($cellHref)
                 <a

--- a/resources/views/components/layouts/partials/table-row.blade.php
+++ b/resources/views/components/layouts/partials/table-row.blade.php
@@ -68,9 +68,11 @@
         {{-- bound through Alpine like the head and filter cells, so toggling a sticky column takes effect without a re-render --}}
         @php
             $cellHref = ($allowSoftDeletes && ($record['deleted_at'] ?? null)) ? null : ($record['href'] ?? null);
-            $cellClasses = 'border-b border-gray-100 dark:border-secondary-700/50 text-sm p-0'
-                . (str_contains($cellAttrClasses, 'whitespace-') ? '' : ' whitespace-nowrap max-w-xs overflow-hidden text-ellipsis')
-                . ($cellAttrClasses === '' ? '' : ' ' . $cellAttrClasses);
+            $cellClasses = \Illuminate\Support\Arr::toCssClasses([
+                'border-b border-gray-100 dark:border-secondary-700/50 text-sm p-0',
+                'whitespace-nowrap max-w-xs overflow-hidden text-ellipsis' => ! str_contains($cellAttrClasses, 'whitespace-'),
+                $cellAttrClasses => $cellAttrClasses !== '',
+            ]);
             $cellSticky = '($wire.stickyCols || []).includes(' . \Illuminate\Support\Js::from($col) . ')';
         @endphp
         <td
@@ -79,15 +81,13 @@
             x-bind:class="{!! $cellSticky !!} ? 'sticky left-0 border-r bg-white dark:bg-secondary-800 dark:text-gray-50' : ''"
             x-bind:style="{!! $cellSticky !!} ? 'z-index: 2' : ''"
         >
-            @if ($cellHref)
-                <a
-                    @if ($useWireNavigate) x-on:click.prevent="$el.href && Livewire.navigate($el.href)" @endif
-                    href="{{ $cellHref }}"
-                    class="block px-3 py-2.5"
-                >
-            @else
-                <div class="px-3 py-2.5">
-            @endif
+            {{-- always an anchor: without an href it is inert, and pairing the
+                 tag here keeps the closing tag in the same branch as the opening one --}}
+            <a
+                @if ($cellHref) href="{{ $cellHref }}" @endif
+                @if ($cellHref && $useWireNavigate) x-on:click.prevent="$el.href && Livewire.navigate($el.href)" @endif
+                class="block px-3 py-2.5"
+            >
             @php
                 $hasLeftAppend = isset($leftAppend[$col]);
                 $hasRightAppend = isset($rightAppend[$col]);
@@ -139,11 +139,7 @@
                     @endif
                 @endforeach
             @endif
-            @if ($cellHref)
-                </a>
-            @else
-                </div>
-            @endif
+            </a>
         </td>
     @endforeach
     @if ($rowActions || ($showRestoreButton && $allowSoftDeletes))

--- a/resources/views/components/layouts/table.blade.php
+++ b/resources/views/components/layouts/table.blade.php
@@ -153,7 +153,7 @@
                                         <x-icon
                                             name="funnel"
                                             class="h-4 w-4 cursor-pointer"
-                                            x-on:click="$tsui.open.slide('data-table-sidebar-' + $wire.id.toLowerCase())"
+                                            x-on:click="$wire.showSidebar().then(() => {$tsui.open.slide('data-table-sidebar-' + $wire.id.toLowerCase());})"
                                         />
                                     @endif
                                 </div>
@@ -197,7 +197,7 @@
                                         flat
                                         sm
                                         icon="cog-6-tooth"
-                                        x-on:click="$tsui.open.slide('data-table-sidebar-' + $wire.id.toLowerCase())"
+                                        x-on:click="$wire.showSidebar().then(() => {$tsui.open.slide('data-table-sidebar-' + $wire.id.toLowerCase());})"
                                     />
                                 </div>
                             </x-tall-datatables::table.head-cell>

--- a/resources/views/components/layouts/table.blade.php
+++ b/resources/views/components/layouts/table.blade.php
@@ -153,6 +153,8 @@
                                         <x-icon
                                             name="funnel"
                                             class="h-4 w-4 cursor-pointer"
+                                            wire:target="showSidebar"
+                                            wire:loading.class="animate-spin"
                                             x-on:click="$wire.showSidebar().then(() => {$tsui.open.slide('data-table-sidebar-' + $wire.id.toLowerCase());})"
                                         />
                                     @endif
@@ -196,6 +198,7 @@
                                         color="secondary"
                                         flat
                                         sm
+                                        loading="showSidebar"
                                         icon="cog-6-tooth"
                                         x-on:click="$wire.showSidebar().then(() => {$tsui.open.slide('data-table-sidebar-' + $wire.id.toLowerCase());})"
                                     />

--- a/resources/views/livewire/data-table.blade.php
+++ b/resources/views/livewire/data-table.blade.php
@@ -1,22 +1,21 @@
 <x-tall-datatables::data-table-wrapper :attributes="$componentAttributes">
     @includeWhen($includeBefore, $includeBefore)
     @if ($hasSidebar && $rendersSidebar)
-        @teleport('body')
-            <x-slide
-                id="data-table-sidebar-{{ strtolower($this->getId()) }}"
-                size="2xl"
-            >
-                <x-tall-datatables::options />
-                <x-slot:footer>
-                    <x-button
-                        color="secondary"
-                        light
-                        :text="__('Close')"
-                        x-on:click="$tsui.close.slide('data-table-sidebar-{{ strtolower($this->getId()) }}');"
-                    />
-                </x-slot>
-            </x-slide>
-        @endteleport
+        {{-- the slide teleports itself to body since tallstackui v3.2.1 --}}
+        <x-slide
+            id="data-table-sidebar-{{ strtolower($this->getId()) }}"
+            size="2xl"
+        >
+            <x-tall-datatables::options />
+            <x-slot:footer>
+                <x-button
+                    color="secondary"
+                    light
+                    :text="__('Close')"
+                    x-on:click="$tsui.close.slide('data-table-sidebar-{{ strtolower($this->getId()) }}');"
+                />
+            </x-slot>
+        </x-slide>
     @endif
 
     @if ($hasHead)

--- a/resources/views/livewire/data-table.blade.php
+++ b/resources/views/livewire/data-table.blade.php
@@ -1,6 +1,6 @@
 <x-tall-datatables::data-table-wrapper :attributes="$componentAttributes">
     @includeWhen($includeBefore, $includeBefore)
-    @if ($hasSidebar)
+    @if ($hasSidebar && $rendersSidebar)
         @teleport('body')
             <x-slide
                 id="data-table-sidebar-{{ strtolower($this->getId()) }}"

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -86,6 +86,8 @@ class DataTable extends Component
     #[Locked]
     public bool $hasSidebar = true;
 
+    public bool $rendersSidebar = false;
+
     public bool $hasStickyCols = true;
 
     public string $headline = '';
@@ -207,6 +209,11 @@ class DataTable extends Component
     protected function getTableActions(): array
     {
         return [];
+    }
+
+    public function showSidebar(): void
+    {
+        $this->rendersSidebar = true;
     }
 
     #[Renderless]

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -86,8 +86,6 @@ class DataTable extends Component
     #[Locked]
     public bool $hasSidebar = true;
 
-    public bool $rendersSidebar = false;
-
     public bool $hasStickyCols = true;
 
     public string $headline = '';
@@ -121,6 +119,8 @@ class DataTable extends Component
 
     #[Locked]
     public bool $positiveEmptyState = false;
+
+    public bool $rendersSidebar = false;
 
     public string $search = '';
 
@@ -209,11 +209,6 @@ class DataTable extends Component
     protected function getTableActions(): array
     {
         return [];
-    }
-
-    public function showSidebar(): void
-    {
-        $this->rendersSidebar = true;
     }
 
     #[Renderless]
@@ -836,6 +831,11 @@ class DataTable extends Component
         $this->rebuildTextFilterGroup();
         $this->cacheState();
         $this->loadData();
+    }
+
+    public function showSidebar(): void
+    {
+        $this->rendersSidebar = true;
     }
 
     #[Renderless]

--- a/tests/Browser/KanbanBrowserTest.php
+++ b/tests/Browser/KanbanBrowserTest.php
@@ -63,9 +63,17 @@ describe('Kanban View', function (): void {
                     const start = Date.now();
                     const check = () => {
                         if (Date.now() - start > 15000) return resolve({ timeout: true });
-                        const cards = document.querySelectorAll("[x-sort\\:item]");
-                        if (cards.length >= 2) {
-                            return resolve({ timeout: false, cardCount: cards.length });
+                        // scoped to the lanes: the options sidebar has a
+                        // sortable column list of its own, and counting that
+                        // kept this green while a lane sat empty
+                        const lanes = [...document.querySelectorAll('[x-sort\\:group="kanban"]')];
+                        const perLane = lanes.map((l) => l.querySelectorAll("[x-sort\\:item]").length);
+                        if (lanes.length >= 2 && perLane.every((n) => n >= 1)) {
+                            return resolve({
+                                timeout: false,
+                                cardCount: perLane.reduce((a, b) => a + b, 0),
+                                perLane,
+                            });
                         }
                         setTimeout(check, 500);
                     };
@@ -77,6 +85,7 @@ describe('Kanban View', function (): void {
         $data = is_array($result) && isset($result[0]) ? $result[0] : $result;
         expect($data['timeout'])->toBeFalse('Timed out waiting for kanban cards');
         expect($data['cardCount'])->toBeGreaterThanOrEqual(2);
+        expect($data['perLane'])->toBe([1, 1]);
     });
 
     it('shows layout switcher buttons when multiple layouts available', function (): void {

--- a/tests/Browser/ResetLayoutBrowserTest.php
+++ b/tests/Browser/ResetLayoutBrowserTest.php
@@ -33,6 +33,11 @@ describe('Reset layout', function (): void {
         $page->wait(2);
 
         $result = $page->script('async () => {
+            // The sidebar is rendered on first open, so it has to be requested
+            // before the options component exists at all.
+            await window.Livewire.all()[0].$wire.showSidebar();
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+
             const el = document.querySelector(\'[x-data^="datatableOptions"]\');
 
             if (! el) {

--- a/tests/Browser/SidebarOnDemandBrowserTest.php
+++ b/tests/Browser/SidebarOnDemandBrowserTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * Browser Tests for the on-demand options sidebar
+ *
+ * Server side tests only prove whether the markup is sent. Whether the slide
+ * actually opens, and still shows the server state on a second open, only
+ * shows up in a real browser: the slide is teleported to <body> and lives
+ * outside the component root, so a stale node would never surface in a
+ * Livewire test.
+ */
+
+use Tests\Fixtures\Livewire\PostDataTable;
+
+beforeEach(function (): void {
+    $manifestPath = dirname(__DIR__, 2) . '/dist/build/manifest.json';
+    if (! file_exists($manifestPath)) {
+        $this->markTestSkipped('Browser tests require built assets. Run: npm run build');
+    }
+
+    $this->user = createTestUser(['name' => 'Test User', 'email' => 'sidebar-on-demand@example.com']);
+
+    for ($i = 1; $i <= 3; $i++) {
+        createTestPost([
+            'user_id' => $this->user->getKey(),
+            'title' => 'Post Title ' . $i,
+            'content' => 'Content ' . $i,
+            'is_published' => true,
+        ]);
+    }
+});
+
+describe('Options sidebar on demand', function (): void {
+    it('is absent until the cog is clicked, then opens with its content', function (): void {
+        $page = visitLivewire(PostDataTable::class);
+
+        $page->wait(2);
+
+        $result = $page->script('async () => {
+            const before = document.querySelectorAll(\'[x-data^="datatableOptions"]\').length;
+
+            const button = [...document.querySelectorAll("[x-on\\\\:click]")]
+                .find((el) => (el.getAttribute("x-on:click") || "").includes("showSidebar"));
+
+            if (! button) {
+                return "no-opener";
+            }
+
+            button.click();
+            await new Promise((resolve) => setTimeout(resolve, 2500));
+
+            const el = document.querySelector(\'[x-data^="datatableOptions"]\');
+
+            if (! el) {
+                return "no-options-component";
+            }
+
+            const options = window.Alpine.$data(el);
+
+            return JSON.stringify({
+                before,
+                cols: options.enabledCols.length,
+                // teleported: the slide is a direct child of body, not part of
+                // the livewire root the button sits in
+                outsideRoot: el.closest("[wire\\\\:id]") === null,
+                visible: el.offsetParent !== null,
+            });
+        }');
+
+        $raw = is_array($result) && isset($result[0]) ? $result[0] : $result;
+
+        expect($raw)->not->toBe('no-opener')
+            ->and($raw)->not->toBe('no-options-component');
+
+        $state = json_decode((string) $raw, true);
+
+        expect($state['before'])->toBe(0)
+            ->and($state['cols'])->toBeGreaterThan(0)
+            ->and($state['outsideRoot'])->toBeTrue()
+            ->and($state['visible'])->toBeTrue();
+    });
+
+    it('shows the server state again after closing and reopening', function (): void {
+        $page = visitLivewire(PostDataTable::class);
+
+        $page->wait(2);
+
+        $result = $page->script('async () => {
+            const wire = window.Livewire.all()[0].$wire;
+
+            const opener = () => [...document.querySelectorAll("[x-on\\\\:click]")]
+                .find((el) => (el.getAttribute("x-on:click") || "").includes("showSidebar"));
+
+            opener().click();
+            await new Promise((resolve) => setTimeout(resolve, 2500));
+
+            const closer = [...document.querySelectorAll("[x-on\\\\:click]")]
+                .find((el) => (el.getAttribute("x-on:click") || "").includes("$tsui.close.slide"));
+
+            if (! closer) {
+                return "no-close-button";
+            }
+
+            closer.click();
+            await new Promise((resolve) => setTimeout(resolve, 800));
+
+            opener().click();
+            await new Promise((resolve) => setTimeout(resolve, 1500));
+
+            const el = document.querySelector(\'[x-data^="datatableOptions"]\');
+
+            if (! el) {
+                return "options-gone-after-reopen";
+            }
+
+            const options = window.Alpine.$data(el);
+
+            return JSON.stringify({
+                sidebar: [...options.enabledCols],
+                server: [...wire.enabledCols],
+                visible: el.offsetParent !== null,
+            });
+        }');
+
+        $raw = is_array($result) && isset($result[0]) ? $result[0] : $result;
+
+        expect($raw)->not->toBe('no-close-button')
+            ->and($raw)->not->toBe('options-gone-after-reopen');
+
+        $state = json_decode((string) $raw, true);
+
+        expect($state['sidebar'])->toBe($state['server'])
+            ->and($state['visible'])->toBeTrue();
+    });
+});

--- a/tests/Feature/DefaultColumnsTest.php
+++ b/tests/Feature/DefaultColumnsTest.php
@@ -26,11 +26,12 @@ describe('Global Default Columns', function (): void {
 
         it('renders button when gate is true', function (): void {
             Livewire::test(DefaultColumnsPostDataTable::class)
+                ->call('showSidebar')
                 ->assertSee(__('Set as Default'));
         });
 
         it('renders Set as Default button with dialog invoking saveDefaultColumns with bool flag (Livewire v4)', function (): void {
-            $html = Livewire::test(DefaultColumnsPostDataTable::class)->html();
+            $html = Livewire::test(DefaultColumnsPostDataTable::class)->call('showSidebar')->html();
 
             expect($html)->toContain('$wire.saveDefaultColumns(true)')
                 ->and($html)->toContain('$wire.saveDefaultColumns(false)')
@@ -38,7 +39,7 @@ describe('Global Default Columns', function (): void {
         });
 
         it('renders Reset Layout button calling the alpine wrapper, not $wire directly', function (): void {
-            $html = Livewire::test(DefaultColumnsPostDataTable::class)->html();
+            $html = Livewire::test(DefaultColumnsPostDataTable::class)->call('showSidebar')->html();
 
             // The alpine wrapper awaits $wire.resetLayout() and then pulls the
             // reset columns back into the sidebar. Calling $wire directly leaves

--- a/tests/Feature/SidebarOnDemandTest.php
+++ b/tests/Feature/SidebarOnDemandTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Livewire\Livewire;
+use Tests\Fixtures\Livewire\PostDataTable;
+
+beforeEach(function (): void {
+    // Blade caches compiled templates by content hash, so a stale compile from
+    // an earlier run would keep this test green even without the change.
+    Artisan::call('view:clear');
+
+    $this->user = createTestUser();
+    $this->actingAs($this->user);
+});
+
+it('keeps the options sidebar out of the initial response', function (): void {
+    Livewire::test(PostDataTable::class)
+        ->assertSet('rendersSidebar', false)
+        ->assertDontSee(__('Save filter'))
+        ->assertDontSee(__('Adding to new OR group'));
+});
+
+it('renders the options sidebar once showSidebar was called', function (): void {
+    Livewire::test(PostDataTable::class)
+        ->call('showSidebar')
+        ->assertSet('rendersSidebar', true)
+        ->assertSee(__('Save filter'))
+        ->assertSee(__('Adding to new OR group'));
+});
+
+it('sends markup back when showSidebar is called, so the slide is in the dom before it opens', function (): void {
+    // Not #[Renderless]: the slide is teleported to <body>, so an island morph
+    // would never reach the live node. The full re-render is what puts it there.
+    $component = Livewire::test(PostDataTable::class)->call('showSidebar');
+
+    expect($component->effects['html'] ?? null)->not->toBeNull();
+});


### PR DESCRIPTION
The options sidebar carries the column list, the filter builder and the grouping settings. It was rendered on every request, closed, for every table on the page.

`rendersSidebar` now gates the slide, and every opener calls `showSidebar()` before opening it, so the markup is built the first time someone asks for it and stays for the life of the component. The buttons show a loading state while that request runs.

Measured locally, same run, only the guard flipped, 15 rows:

| | always rendered | on demand |
| --- | ---: | ---: |
| time | 90.8 ms | 40.6 ms |
| markup | 324 KB | 210 KB |
| view renders | 375 | 136 |

Measured on flux.team-nifty.com, each route visited with and without the guard back to back so drift cancels out:

| | routes | median difference |
| --- | ---: | ---: |
| with a table | 106 | **-145 ms** |
| without a table | 83 | -7 ms |

The second row is the control: a page without a table cannot benefit, and it does not.

The saving is the 375 view renders, not the 114 KB. Blade costs per component instantiated, not per byte, and a table page is a few hundred instantiations of which most were the closed dialog. A second candidate, the table head, looked large in the DOM but turned out to send 18 to 24 KB and buy no measurable time, so it was dropped.

Two things came out of the work that are not the point of it. The table cells are built inline instead of through `x-tall-datatables::table.cell`, which is where most of the 375 view renders went. And the sticky binding in the row partial ran through `{{ }}`, so it reached the markup as `&#039;` — it worked in a browser but did not match the rest of the table, and it is now `{!! !!}`.

The last commit raises the tallstackui floor from `^3.0` to `^3.2.1`. From that version on the slide wraps itself in `<template x-teleport="body">`, which makes the `@teleport('body')` around the sidebar dead weight, so it goes. v3.1.1 and earlier leave the slide where it is rendered, which is why the wrapper could not be removed under the old constraint. Verified locally against v3.5.14.

Verified in a browser: the slide opens from the gear, lands outside the livewire root and is visible, closing and reopening still shows the server state, and the response carries html rather than being renderless. `SidebarOnDemandTest` fails without the guard.
