### PR TITLE
ci: publish main plus built assets on a main-dist branch

### DIFF
--- a/.github/workflows/build-main-assets.yml
+++ b/.github/workflows/build-main-assets.yml
@@ -1,0 +1,47 @@
+name: Build main assets
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: main-dist
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - name: Build frontend assets
+        run: npm run build
+
+      # main-dist is main plus the built dist/, so a consumer can require
+      # dev-main-dist and get a working frontend without cutting a release.
+      # The branch is rebuilt from main on every run, never merged back.
+      - name: Publish main-dist
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B main-dist
+          git add -f dist/
+          git commit -m "Build assets for ${{ github.sha }}"
+          git push -f origin main-dist


### PR DESCRIPTION
`/dist` is gitignored and only ever committed into a release tag, so `composer require team-nifty-gmbh/tall-datatables:dev-main` installs the package without a frontend. Testing an unreleased state means cutting a release first.

This workflow builds on every push to `main` and force pushes the result to a `main-dist` branch: main plus `dist/`. A consumer requires it as

```
"team-nifty-gmbh/tall-datatables": "dev-main-dist as 2.6.999"
```

and gets a working build without a release. The alias keeps the version high enough for anything asking for `^2.6`.

Nothing about `main` changes. `dist/` stays ignored there, a local `npm run build` still leaves a clean tree, and `release.yml` keeps building its own assets into the tag. The two never write to the same ref, and `main-dist` is rebuilt from `main` on every run, so it never has an empty commit and never merges back.

Mirrors `release.yml`: `ubuntu-latest`, `actions/checkout@v7`, Node 22. `npm ci` rather than `npm install`, since `package-lock.json` is committed and this runs unattended. No `composer install` — the build is vite only.

The build writes to `dist/build/assets` with `dist/build/manifest.json`, which is what `verify-release-assets.yml` already checks for.

The same pattern runs in flux-core (#2063).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFNYmyLk7oAdKm5E3V1UuP
