### PR TITLE
perf(data-table): emit the row selection checkbox as a plain input

### DIFF
--- a/resources/views/components/layouts/partials/table-row.blade.php
+++ b/resources/views/components/layouts/partials/table-row.blade.php
@@ -31,16 +31,24 @@
     {{ $rowAttributes->merge(['class' => 'group hover:bg-gray-50 dark:hover:bg-secondary-900/50 transition-colors']) }}
 >
     @if ($isSelectable)
+        @php
+            $recordKey = json_encode($record[$modelKeyName] ?? $index);
+        @endphp
         <td
             class="border-b border-gray-100 px-3 py-2.5 text-sm whitespace-nowrap dark:border-secondary-700/50/50"
         >
             <div
                 {{ $selectAttributes->merge(['class' => 'flex items-center justify-center gap-1']) }}
             >
-                <x-checkbox
-                    x-on:click.stop="$wire.toggleSelected({{ json_encode($record[$modelKeyName] ?? $index) }})"
-                    x-bind:checked="$wire.selected.includes('*') ? !$wire.wildcardSelectExcluded.includes({{ json_encode($record[$modelKeyName] ?? $index) }}) : $wire.selected.includes({{ json_encode($record[$modelKeyName] ?? $index) }})"
-                    sm
+                {{-- the tallstackui checkbox renders four views per row for a
+                     label, a position and an error slot this table never uses,
+                     so the input is emitted directly. RowCheckboxMarkupTest
+                     pins the classes against the component. --}}
+                <input
+                    type="checkbox"
+                    class="form-checkbox dark:border-dark-600 border-1 dark:bg-dark-800 rounded border-gray-300 bg-white ring-0 ring-offset-0 focus:ring-0 focus:ring-offset-0 h-4 w-4 text-primary-500 focus:ring-primary-500 dark:ring-offset-dark-900"
+                    x-on:click.stop="$wire.toggleSelected({{ $recordKey }})"
+                    x-bind:checked="$wire.selected.includes('*') ? !$wire.wildcardSelectExcluded.includes({{ $recordKey }}) : $wire.selected.includes({{ $recordKey }})"
                 />
             </div>
         </td>

--- a/tests/Feature/RowCheckboxMarkupTest.php
+++ b/tests/Feature/RowCheckboxMarkupTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Blade;
+use Livewire\Livewire;
+use Tests\Fixtures\Livewire\PostDataTable;
+
+beforeEach(function (): void {
+    Artisan::call('view:clear');
+
+    $this->user = createTestUser();
+    $this->actingAs($this->user);
+});
+
+it('emits the row checkbox as a plain input, not as the component', function (): void {
+    createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Selectable Row']);
+
+    $html = preg_replace('/\s+/', ' ', Livewire::test(PostDataTable::class)->call('loadData')->html());
+
+    $inputs = preg_match_all('/<input[^>]*type="checkbox"/', $html);
+    // the component wraps every checkbox in a label for a label text the table
+    // never passes, which is what made it four views per row. The select all
+    // box in the head is still the component, the row boxes must not be.
+    $wrapped = preg_match_all('/<label class="relative inline-flex cursor-pointer items-start">/', $html);
+
+    expect($html)->toContain('$wire.toggleSelected(')
+        ->and($inputs)->toBe(2)
+        ->and($wrapped)->toBeLessThan($inputs);
+});
+
+it('keeps the row checkbox classes in step with the tallstackui component', function (): void {
+    createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Selectable Row']);
+
+    $pattern = '/<input[^>]*type="checkbox"[^>]*class="([^"]*)"/';
+
+    $component = preg_replace('/\s+/', ' ', Blade::render('<x-checkbox sm />'));
+    preg_match($pattern, $component, $expected);
+
+    $html = preg_replace('/\s+/', ' ', Livewire::test(PostDataTable::class)->call('loadData')->html());
+    preg_match($pattern, $html, $actual);
+
+    expect($expected[1] ?? 'component markup changed')
+        ->not->toBe('component markup changed')
+        ->and($actual[1] ?? 'no inlined checkbox')
+        ->toBe($expected[1]);
+});


### PR DESCRIPTION
Every selectable row rendered an `<x-checkbox sm>`. TallStackUI turns that into four views: the input, a radio wrapper, a form wrapper carrying a label and a position, and an error slot. The table passes none of them — it sets `x-on:click` and `x-bind:checked` and nothing else.

Profiled locally with the Blade engine wrapped, exclusive time and call count per view, median of seven runs after a warm-up. Same table, 15 rendered rows, the only difference being `isSelectable`:

| | total | views | renders |
| --- | ---: | ---: | ---: |
| with the selection column | 40.6 ms | 27.9 ms | 139 |
| without | 24.8 ms | 16.0 ms | 74 |

So the selection column cost **65 view renders and 15.8 ms** for 15 rows — 4.3 renders and 1.05 ms per row, 39% of the whole render.

Emitting the input directly leaves the row partial as the only view rendered per row:

| 15 rows | before | after |
| --- | ---: | ---: |
| time | 42.0 ms | 31.2 ms |
| view renders | 139 | 79 |

Same shape as the cells in #288.

## The classes

They are copied from what the component emits for `sm`. `RowCheckboxMarkupTest` renders `<x-checkbox sm />` and compares its class list against the one in the table on every run, so a TallStackUI upgrade that restyles the checkbox fails the test instead of drifting the two apart unnoticed. A second test pins that the row boxes are not wrapped in the component's label.

## Scope

The select-all box in the head is still the component. It renders once per table, not once per row, so it is not worth the divergence.

Columns were measured too and are not a lever: going from 1 to 9 columns adds 8.9 ms and **zero** extra view renders, 0.07 ms per cell. The inline cells from #288 do their job.

Full suite green: 1336 feature tests, 110 browser tests, including the selection and select-all browser tests that drive this checkbox for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFNYmyLk7oAdKm5E3V1UuP
