### PR TITLE
Guard the relation circle instead of capping to-many depth

### DIFF
--- a/config/tall-datatables.php
+++ b/config/tall-datatables.php
@@ -48,15 +48,16 @@ return [
     |--------------------------------------------------------------------------
     |
     | Every to-many hop in a column path multiplies the loaded records by the cap
-    | above, so orders.positions.tags.name already pulls 50^3 records per row. A
-    | relation tree also lets a user walk a self referencing relation in a circle,
-    | which never terminates on its own. This caps how many to-many hops a single
-    | column path may contain, columns beyond it are dropped.
-    | Set to 0 to disable the cap.
+    | above, so orders.positions.tags.name already pulls 50^3 records per row.
+    | This caps how many to-many hops a single column path may contain, columns
+    | beyond it are dropped. A path whose to-many hops return to a model it has
+    | already visited is dropped no matter the number, because a relation tree
+    | lets a user walk a self referencing relation in a circle.
+    | Set to 0 to disable both.
     |
     */
 
-    'max_relation_column_to_many_hops' => env('TALL_DATATABLES_MAX_RELATION_COLUMN_TO_MANY_HOPS', 1),
+    'max_relation_column_to_many_hops' => env('TALL_DATATABLES_MAX_RELATION_COLUMN_TO_MANY_HOPS', 2),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/tall-datatables.php
+++ b/config/tall-datatables.php
@@ -49,15 +49,17 @@ return [
     |
     | Every to-many hop in a column path multiplies the loaded records by the cap
     | above, so orders.positions.tags.name already pulls 50^3 records per row.
-    | This caps how many to-many hops a single column path may contain, columns
-    | beyond it are dropped. A path whose to-many hops return to a model it has
-    | already visited is dropped no matter the number, because a relation tree
-    | lets a user walk a self referencing relation in a circle.
-    | Set to 0 to disable both.
+    | How deep a column reaches is the user's decision though, so nothing is
+    | capped by default. Set a number here to drop columns that chain more
+    | to-many hops than an instance is willing to load.
+    |
+    | Independent of this, a path whose to-many hop returns to a model it has
+    | already visited is always dropped. That circle is what a relation tree
+    | lets a user click together by accident, never a column anybody wants.
     |
     */
 
-    'max_relation_column_to_many_hops' => env('TALL_DATATABLES_MAX_RELATION_COLUMN_TO_MANY_HOPS', 2),
+    'max_relation_column_to_many_hops' => env('TALL_DATATABLES_MAX_RELATION_COLUMN_TO_MANY_HOPS', 0),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Traits/DataTables/SupportsRelations.php
+++ b/src/Traits/DataTables/SupportsRelations.php
@@ -367,6 +367,7 @@ trait SupportsRelations
             $fieldName = array_pop($segments);
 
             $toManyHops = 0;
+            $visitedModels = [$modelBase::class];
 
             $path = null;
             $model = null;
@@ -390,20 +391,30 @@ trait SupportsRelations
                     continue 2;
                 }
 
+                try {
+                    $model = $relationInstance->getRelated();
+                } catch (Throwable) {
+                    $model = null;
+                }
+
+                $isToManyHop = $relationInstance instanceof HasMany
+                    || $relationInstance instanceof HasManyThrough
+                    || $relationInstance instanceof BelongsToMany
+                    || $relationInstance instanceof MorphMany;
+
                 // Each to-many hop multiplies the hydrated object graph by
-                // max_relation_column_values, so a path that chains several of them
+                // max_relation_column_values, so a path that chains more of them than
+                // the cap allows exhausts the worker long before it renders. A hop back
+                // onto a model the path already passed is dropped whatever the cap says,
+                // that is the circle a relation tree lets a user click together
                 // (comments.post.comments.body, or a self referencing morph such as
-                // category.categorizables.categories) exhausts the worker long before
-                // it renders. Relation trees let a user click such a path together, so
-                // the column is dropped rather than trusted.
+                // category.categorizables.categories).
                 if ($maxToManyHops > 0
+                    && $isToManyHop
                     && (
-                        $relationInstance instanceof HasMany
-                        || $relationInstance instanceof HasManyThrough
-                        || $relationInstance instanceof BelongsToMany
-                        || $relationInstance instanceof MorphMany
+                        ++$toManyHops > $maxToManyHops
+                        || ($model && in_array($model::class, $visitedModels, true))
                     )
-                    && ++$toManyHops > $maxToManyHops
                 ) {
                     $this->enabledCols = array_values(array_diff($this->enabledCols, [$enabledCol]));
                     $with = $withBeforeCol;
@@ -412,10 +423,8 @@ trait SupportsRelations
                     continue 2;
                 }
 
-                try {
-                    $model = $relationInstance->getRelated();
-                } catch (Throwable) {
-                    $model = null;
+                if ($model) {
+                    $visitedModels[] = $model::class;
                 }
 
                 // a MorphTo resolves to several related tables, so its columns must stay unqualified

--- a/src/Traits/DataTables/SupportsRelations.php
+++ b/src/Traits/DataTables/SupportsRelations.php
@@ -402,25 +402,24 @@ trait SupportsRelations
                     || $relationInstance instanceof BelongsToMany
                     || $relationInstance instanceof MorphMany;
 
-                // Each to-many hop multiplies the hydrated object graph by
-                // max_relation_column_values, so a path that chains more of them than
-                // the cap allows exhausts the worker long before it renders. A hop back
-                // onto a model the path already passed is dropped whatever the cap says,
-                // that is the circle a relation tree lets a user click together
-                // (comments.post.comments.body, or a self referencing morph such as
-                // category.categorizables.categories).
-                if ($maxToManyHops > 0
-                    && $isToManyHop
-                    && (
-                        ++$toManyHops > $maxToManyHops
-                        || ($model && in_array($model::class, $visitedModels, true))
-                    )
-                ) {
-                    $this->enabledCols = array_values(array_diff($this->enabledCols, [$enabledCol]));
-                    $with = $withBeforeCol;
-                    $relationTables = $relationTablesBeforeCol;
+                // The relation tree offers relations one level at a time and never notices
+                // when a path returns to a model it already visited, so a self referencing
+                // relation can be clicked into a circle (category.categorizables.categories)
+                // that keeps multiplying the hydrated object graph until the worker dies.
+                // A circle is never a column anybody wants, so it is dropped. Depth alone
+                // is the user's choice and only capped where an instance asks for it.
+                if ($isToManyHop) {
+                    $toManyHops++;
 
-                    continue 2;
+                    if (($model && in_array($model::class, $visitedModels, true))
+                        || ($maxToManyHops > 0 && $toManyHops > $maxToManyHops)
+                    ) {
+                        $this->enabledCols = array_values(array_diff($this->enabledCols, [$enabledCol]));
+                        $with = $withBeforeCol;
+                        $relationTables = $relationTablesBeforeCol;
+
+                        continue 2;
+                    }
                 }
 
                 if ($model) {

--- a/tests/Feature/ChainedToManyRelationColumnTest.php
+++ b/tests/Feature/ChainedToManyRelationColumnTest.php
@@ -19,14 +19,24 @@ function constructWithOf(object $component): array
     return (fn () => $this->constructWith())->call($component);
 }
 
-it('drops a column that chains more to-many relations than the cap allows', function (): void {
+it('drops a column that walks a relation circle', function (): void {
     $component = Livewire::test(ChainedToManyDataTable::class);
 
     expect($component->get('enabledCols'))
+        ->not->toContain('comments.post.comments.body')
         ->not->toContain('comments.post.comments.user.posts.title');
 });
 
-it('does not eager load any hop of the chained to-many path', function (): void {
+it('drops the circle even with no cap configured', function (): void {
+    config(['tall-datatables.max_relation_column_to_many_hops' => 0]);
+
+    $component = Livewire::test(ChainedToManyDataTable::class);
+
+    expect($component->get('enabledCols'))
+        ->not->toContain('comments.post.comments.body');
+});
+
+it('does not eager load any hop of the dropped path', function (): void {
     $with = constructWithOf(Livewire::test(ChainedToManyDataTable::class)->instance())[0];
 
     // not even a partial hop of the dropped path may survive, each one multiplies
@@ -50,19 +60,12 @@ it('keeps a column with two to-many hops through distinct models', function (): 
         ->toContain('comments.tags.name');
 });
 
-it('drops a column whose to-many hops return to a model the path already visited', function (): void {
-    $component = Livewire::test(ChainedToManyDataTable::class);
-
-    expect($component->get('enabledCols'))
-        ->not->toContain('comments.post.comments.body');
-});
-
-it('keeps the chained column when the cap is disabled', function (): void {
-    config(['tall-datatables.max_relation_column_to_many_hops' => 0]);
+it('drops a column beyond a cap an instance configures', function (): void {
+    config(['tall-datatables.max_relation_column_to_many_hops' => 1]);
 
     $component = Livewire::test(ChainedToManyDataTable::class);
 
     expect($component->get('enabledCols'))
-        ->toContain('comments.post.comments.user.posts.title')
-        ->toContain('comments.post.comments.body');
+        ->toContain('comments.body')
+        ->not->toContain('comments.tags.name');
 });

--- a/tests/Feature/ChainedToManyRelationColumnTest.php
+++ b/tests/Feature/ChainedToManyRelationColumnTest.php
@@ -19,7 +19,7 @@ function constructWithOf(object $component): array
     return (fn () => $this->constructWith())->call($component);
 }
 
-it('drops a column that chains more than one to-many relation', function (): void {
+it('drops a column that chains more to-many relations than the cap allows', function (): void {
     $component = Livewire::test(ChainedToManyDataTable::class);
 
     expect($component->get('enabledCols'))
@@ -43,11 +43,26 @@ it('keeps columns with a single to-many hop and none at all', function (): void 
         ->toContain('comments.body');
 });
 
+it('keeps a column with two to-many hops through distinct models', function (): void {
+    $component = Livewire::test(ChainedToManyDataTable::class);
+
+    expect($component->get('enabledCols'))
+        ->toContain('comments.tags.name');
+});
+
+it('drops a column whose to-many hops return to a model the path already visited', function (): void {
+    $component = Livewire::test(ChainedToManyDataTable::class);
+
+    expect($component->get('enabledCols'))
+        ->not->toContain('comments.post.comments.body');
+});
+
 it('keeps the chained column when the cap is disabled', function (): void {
     config(['tall-datatables.max_relation_column_to_many_hops' => 0]);
 
     $component = Livewire::test(ChainedToManyDataTable::class);
 
     expect($component->get('enabledCols'))
-        ->toContain('comments.post.comments.user.posts.title');
+        ->toContain('comments.post.comments.user.posts.title')
+        ->toContain('comments.post.comments.body');
 });

--- a/tests/Feature/NestedRelationColumnValueTest.php
+++ b/tests/Feature/NestedRelationColumnValueTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Support\Facades\Cache;
+use Livewire\Livewire;
+use Tests\Fixtures\Livewire\ChainedToManyDataTable;
+use Tests\Fixtures\Models\Tag;
+
+beforeEach(function (): void {
+    Cache::flush();
+
+    $this->user = createTestUser();
+    $this->actingAs($this->user);
+
+    $post = createTestPost(['user_id' => $this->user->getKey(), 'title' => 'Root']);
+    $comment = createTestComment(['post_id' => $post->getKey(), 'user_id' => $this->user->getKey()]);
+    $comment->tags()->attach(Tag::create(['name' => 'Urgent'])->getKey());
+});
+
+function firstRowOf(object $component): object
+{
+    return (fn () => $this->buildSearch()->get())->call($component)->first();
+}
+
+it('loads the value behind two to-many hops', function (): void {
+    $row = firstRowOf(Livewire::test(ChainedToManyDataTable::class)->instance());
+
+    expect($row->comments->first()->tags->first()?->name)->toBe('Urgent');
+});

--- a/tests/Fixtures/Livewire/ChainedToManyDataTable.php
+++ b/tests/Fixtures/Livewire/ChainedToManyDataTable.php
@@ -13,6 +13,10 @@ class ChainedToManyDataTable extends DataTable
         'user.name',
         // a single to-many hop, the supported case
         'comments.body',
+        // two to-many hops through distinct models, a list of a list
+        'comments.tags.name',
+        // two to-many hops that return to the model the path started on
+        'comments.post.comments.body',
         // three to-many hops: comments -> post -> comments -> user -> posts
         'comments.post.comments.user.posts.title',
     ];

--- a/tests/Fixtures/Models/Comment.php
+++ b/tests/Fixtures/Models/Comment.php
@@ -5,6 +5,7 @@ namespace Tests\Fixtures\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 class Comment extends Model
 {
@@ -32,6 +33,11 @@ class Comment extends Model
             'post_id',
             'user_id'
         );
+    }
+
+    public function tags(): MorphToMany
+    {
+        return $this->morphToMany(Tag::class, 'taggable');
     }
 
     public function user(): BelongsTo


### PR DESCRIPTION
## Problem

`max_relation_column_to_many_hops` was introduced with a default of 1 after a column path walked a relation circle and died at the execution time limit. The cap works on depth, but depth was never the problem.

A path such as `addresses.mediaConsultants.name` on a contacts table walks two to-many hops (contact hasMany addresses, address belongsToMany users) through three distinct models. It is the ordinary "list of a list" a relation tree invites, it worked before the cap, and since the cap it is removed from `enabledCols` while the sidebar checkbox stays ticked. The column disappears from the table and from the export column list with no explanation.

Verified on a running instance for `['customer_number', 'addresses.sbm_media_consultants.name']`:

```
cap=1
surviving cols: ["customer_number"]
```

## Change

- A path whose to-many hop returns to a model it already visited is dropped, whatever the cap says. That circle (`category.categorizables.categories`, `comments.post.comments.body`) is what the relation tree lets a user assemble by accident and the reason the cap was written.
- `max_relation_column_to_many_hops` defaults to 0, so depth is no longer capped out of the box. An instance that wants a limit sets one, and the per relation `max_relation_column_values` still bounds every single hop.

## Tests

`ChainedToManyRelationColumnTest` now covers the circle (dropped, also with no cap configured), the two hop path through distinct models (kept), and an explicitly configured cap (honoured). `NestedRelationColumnValueTest` asserts a two hop column actually renders its value. The fixture `Comment` model gets a `tags()` morphToMany so a genuine second to-many hop exists.