### PR TITLE
Cover the Set as Default dialog in the browser

### DIFF
--- a/tests/Browser/SaveDefaultColumnsBrowserTest.php
+++ b/tests/Browser/SaveDefaultColumnsBrowserTest.php
@@ -67,4 +67,56 @@ describe('Set as Default', function (): void {
         expect($raw)->toBe('clicked')
             ->and(DatatableUserSetting::where('is_default_columns', true)->count())->toBe(1);
     });
+
+    it('stores the global default and resets other layouts from the confirm button', function (): void {
+        DatatableUserSetting::create([
+            'name' => 'OtherUserLayout',
+            'component' => DefaultColumnsPostDataTable::class,
+            'cache_key' => DefaultColumnsPostDataTable::class,
+            'settings' => ['enabledCols' => ['id']],
+            'is_layout' => true,
+            'is_default_columns' => false,
+            'is_permanent' => false,
+            'authenticatable_id' => $this->user->getKey(),
+            'authenticatable_type' => $this->user->getMorphClass(),
+        ]);
+
+        $page = visitLivewire(DefaultColumnsPostDataTable::class);
+
+        $page->wait(2);
+
+        $result = $page->script('async () => {
+            const clickByText = (text) => {
+                const button = [...document.querySelectorAll("button")]
+                    .find((candidate) => candidate.textContent.trim() === text);
+
+                button?.click();
+
+                return !! button;
+            };
+
+            await window.Livewire.all()[0].$wire.showSidebar();
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+
+            if (! clickByText("Set as Default")) {
+                return "no-set-as-default-button";
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+
+            if (! clickByText("Save default and reset others")) {
+                return "no-dialog-button";
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, 1500));
+
+            return "clicked";
+        }');
+
+        $raw = is_array($result) && isset($result[0]) ? $result[0] : $result;
+
+        expect($raw)->toBe('clicked')
+            ->and(DatatableUserSetting::where('is_default_columns', true)->count())->toBe(1)
+            ->and(DatatableUserSetting::where('is_layout', true)->count())->toBe(0);
+    });
 });

--- a/tests/Browser/SaveDefaultColumnsBrowserTest.php
+++ b/tests/Browser/SaveDefaultColumnsBrowserTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Browser Tests for Set as Default
+ *
+ * The button opens a TallStackUI dialog and only saves from inside its
+ * callbacks, so the server side alone proves nothing: the click has to travel
+ * through the dialog before saveDefaultColumns() is ever reached.
+ */
+
+use TeamNiftyGmbH\DataTable\Models\DatatableUserSetting;
+use Tests\Fixtures\Livewire\DefaultColumnsPostDataTable;
+
+beforeEach(function (): void {
+    $manifestPath = dirname(__DIR__, 2) . '/dist/build/manifest.json';
+    if (! file_exists($manifestPath)) {
+        $this->markTestSkipped('Browser tests require built assets. Run: npm run build');
+    }
+
+    $this->user = createTestUser(['name' => 'Default User', 'email' => 'default-columns@example.com']);
+    $this->actingAs($this->user);
+
+    createTestPost([
+        'user_id' => $this->user->getKey(),
+        'title' => 'Post Title 1',
+        'content' => 'Content 1',
+        'is_published' => true,
+    ]);
+});
+
+describe('Set as Default', function (): void {
+    it('stores the global default columns from the dialog', function (): void {
+        $page = visitLivewire(DefaultColumnsPostDataTable::class);
+
+        $page->wait(2);
+
+        $result = $page->script('async () => {
+            const clickByText = (text) => {
+                const button = [...document.querySelectorAll("button")]
+                    .find((candidate) => candidate.textContent.trim() === text);
+
+                button?.click();
+
+                return !! button;
+            };
+
+            await window.Livewire.all()[0].$wire.showSidebar();
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+
+            if (! clickByText("Set as Default")) {
+                return "no-set-as-default-button";
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+
+            if (! clickByText("Save default only")) {
+                return "no-dialog-button";
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, 1500));
+
+            return "clicked";
+        }');
+
+        $raw = is_array($result) && isset($result[0]) ? $result[0] : $result;
+
+        expect($raw)->toBe('clicked')
+            ->and(DatatableUserSetting::where('is_default_columns', true)->count())->toBe(1);
+    });
+});

--- a/tests/resources/views/components/layouts/app.blade.php
+++ b/tests/resources/views/components/layouts/app.blade.php
@@ -12,6 +12,8 @@
 <body class="antialiased">
     {{ $slot }}
 
+    <x-dialog />
+
     @livewireScripts
     @tallStackUiScript
     @dataTablesScripts


### PR DESCRIPTION
The browser test layout never rendered `<x-dialog />`, so every interaction that runs through a TallStackUI dialog was a silent no-op in the harness and could not be tested.

`Set as Default` is such an interaction: it only calls `saveDefaultColumns()` from inside the dialog callbacks. The server-side tests pass whether or not a click ever reaches the component, so they cannot tell a working button from a dead one.

The new browser test drives the whole path: open the sidebar, click `Set as Default`, click through the dialog, and assert the global default row is written.