### PR TITLE
Format array values element by element on export

### DIFF
--- a/src/Exports/Concerns/ExportsData.php
+++ b/src/Exports/Concerns/ExportsData.php
@@ -41,31 +41,9 @@ trait ExportsData
 
             if (is_null($value) && str_contains($column, '.')) {
                 $value = $this->extractNestedValue($rowArray, explode('.', $column));
-
-                if (is_array($value)) {
-                    // Format every related value on its own, otherwise an element formatter
-                    // (e.g. a boolean rendered as an icon) never sees the individual values.
-                    $value = implode('; ', array_filter(
-                        array_map(
-                            fn ($item) => $this->formatExportValue($item, $formatter, $rowArray),
-                            $value
-                        ),
-                        fn ($item) => $item !== null && $item !== ''
-                    ));
-
-                    $result[$column] = $value;
-
-                    continue;
-                }
             }
 
-            if (! is_null($value) && $formatter) {
-                $value = is_array($value)
-                    ? $this->toPlainText($formatter->format($value, $rowArray))
-                    : $this->formatExportValue($value, $formatter, $rowArray);
-            }
-
-            $result[$column] = $value;
+            $result[$column] = $this->formatExportValue($value, $formatter, $rowArray);
         }
 
         return $result;
@@ -106,18 +84,34 @@ trait ExportsData
     }
 
     /**
-     * Format a single scalar value for the export, unwrapping array formatters so their
-     * element formatter decides. Boolean values are exported as text because their
-     * formatter renders an icon, which strip_tags would reduce to an empty cell.
+     * Format a value for the export, unwrapping array formatters so their element formatter
+     * decides. Boolean values are exported as text because their formatter renders an icon,
+     * which strip_tags would reduce to an empty cell.
      */
     protected function formatExportValue(mixed $value, ?Formatter $formatter, array $context): mixed
     {
-        if (is_null($value) || is_null($formatter)) {
+        if (is_null($value)) {
             return $value;
         }
 
         if ($formatter instanceof ArrayFormatter) {
             $formatter = $formatter->elementFormatter() ?? $formatter;
+        }
+
+        if (is_array($value) && ! $formatter instanceof ArrayFormatter) {
+            // Format every element on its own. Only an ArrayFormatter reads an array; every
+            // other formatter casts its input to string, which fails on one.
+            return implode('; ', array_filter(
+                array_map(
+                    fn (mixed $item) => $this->formatExportValue($item, $formatter, $context),
+                    $value
+                ),
+                fn (mixed $item) => $item !== null && $item !== ''
+            ));
+        }
+
+        if (is_null($formatter)) {
+            return $value;
         }
 
         if ($formatter instanceof BooleanFormatter) {

--- a/tests/Unit/Exports/ExportsDataFormattedTest.php
+++ b/tests/Unit/Exports/ExportsDataFormattedTest.php
@@ -2,8 +2,14 @@
 
 use Illuminate\Database\Eloquent\Model;
 use TeamNiftyGmbH\DataTable\Exports\Concerns\ExportsData;
+use TeamNiftyGmbH\DataTable\Formatters\ArrayFormatter;
+use TeamNiftyGmbH\DataTable\Formatters\BadgeFormatter;
 use TeamNiftyGmbH\DataTable\Formatters\BooleanFormatter;
 use TeamNiftyGmbH\DataTable\Formatters\Contracts\Formatter;
+use TeamNiftyGmbH\DataTable\Formatters\EnumFormatter;
+use TeamNiftyGmbH\DataTable\Formatters\LinkFormatter;
+use TeamNiftyGmbH\DataTable\Formatters\PercentageFormatter;
+use TeamNiftyGmbH\DataTable\Formatters\StringFormatter;
 
 class StubFormatter implements Formatter
 {
@@ -117,5 +123,79 @@ describe('ExportsData formatted export', function (): void {
         };
 
         expect($exporter->testMapRow($row)['status'])->toBeNull();
+    });
+    test('mapRow formats every element of an array value on its own', function (): void {
+        $exporter = new ExportsDataTestClass(
+            ['rates'],
+            ['rates' => new PercentageFormatter()]
+        );
+
+        $row = new class() extends Model
+        {
+            protected $guarded = [];
+
+            public function __construct()
+            {
+                parent::__construct(['rates' => [0.1, 0.255]]);
+            }
+        };
+
+        expect($exporter->testMapRow($row)['rates'])->toBe('10 %; 25,50 %');
+    });
+
+    test('mapRow formats an array value for every scalar formatter', function (Formatter $formatter, string $expected): void {
+        $exporter = new ExportsDataTestClass(['values'], ['values' => $formatter]);
+
+        $row = new class() extends Model
+        {
+            protected $guarded = [];
+
+            public function __construct()
+            {
+                parent::__construct(['values' => ['a', 'b']]);
+            }
+        };
+
+        expect($exporter->testMapRow($row)['values'])->toBe($expected);
+    })->with([
+        'string' => [new StringFormatter(), 'a; b'],
+        'badge' => [new BadgeFormatter(), 'a; b'],
+        'enum' => [new EnumFormatter(), 'A; B'],
+        'link' => [new LinkFormatter(), 'a; b'],
+    ]);
+
+    test('mapRow lets an array formatter render the whole array', function (): void {
+        $exporter = new ExportsDataTestClass(
+            ['tags'],
+            ['tags' => new ArrayFormatter()]
+        );
+
+        $row = new class() extends Model
+        {
+            protected $guarded = [];
+
+            public function __construct()
+            {
+                parent::__construct(['tags' => ['first', 'second']]);
+            }
+        };
+
+        expect($exporter->testMapRow($row)['tags'])->toBe('first second');
+    });
+
+    test('mapRow joins an array value when no formatter is set', function (): void {
+        $exporter = new ExportsDataTestClass(['tags']);
+
+        $row = new class() extends Model
+        {
+            protected $guarded = [];
+
+            public function __construct()
+            {
+                parent::__construct(['tags' => ['first', 'second']]);
+            }
+        };
+
+        expect($exporter->testMapRow($row)['tags'])->toBe('first; second');
     });
 });


### PR DESCRIPTION
## Problem

`ExportsData::mapRow()` handed an array value to the column formatter unchanged:

```php
$value = is_array($value)
    ? $this->toPlainText($formatter->format($value, $rowArray))
    : $this->formatExportValue($value, $formatter, $rowArray);
```

Only `ArrayFormatter` reads an array. Every other formatter casts its input to string, so a column that resolves to a list raised `Array to string conversion` and aborted the queued export.

Affected formatters:

| Formatter | Before |
|---|---|
| `PercentageFormatter`, `BadgeFormatter`, `EnumFormatter`, `StringFormatter`, `ImageFormatter`, `LinkFormatter` | `Array to string conversion`, export job fails |
| `FloatFormatter`, `DurationFormatter` | cast the array to a number and export a silently wrong `1` |
| `MoneyFormatter`, `DateFormatter`, `BooleanFormatter`, `ArrayFormatter` | already fine |

## Why there were two paths

`mapRow()` had two branches for the same case. A column whose value `data_get()` could not resolve went through `extractNestedValue()` and was formatted element by element (added in #255 and the boolean relation fix, so an element formatter sees the individual values). A value `data_get()` returned as an array went to the formatter whole. The element-wise path is the correct one, the whole-array path only holds for `ArrayFormatter`.

## Fix

Both branches now route through `formatExportValue()`, which maps over the elements unless the formatter is an `ArrayFormatter` that renders the array itself. `mapRow()` loses its duplicated branch.