### PR TITLE
Export a json object column as json instead of formatting its fields

### DIFF
--- a/src/Exports/Concerns/ExportsData.php
+++ b/src/Exports/Concerns/ExportsData.php
@@ -99,6 +99,13 @@ trait ExportsData
         }
 
         if (is_array($value) && ! $formatter instanceof ArrayFormatter) {
+            // An associative array is a single structured value, not a set of values: a json
+            // column such as a frozen snapshot carries its fields under their own names, and
+            // handing each of them to a column formatter both fails and loses the names.
+            if (! array_is_list($value)) {
+                return json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            }
+
             // Format every element on its own. Only an ArrayFormatter reads an array; every
             // other formatter casts its input to string, which fails on one.
             return implode('; ', array_filter(

--- a/src/Formatters/PercentageFormatter.php
+++ b/src/Formatters/PercentageFormatter.php
@@ -13,7 +13,7 @@ class PercentageFormatter implements Formatter
 
     public function format(mixed $value, array $context = []): string
     {
-        if (is_null($value)) {
+        if (! is_numeric($value)) {
             return '';
         }
 

--- a/tests/Unit/Exports/ExportsDataFormattedTest.php
+++ b/tests/Unit/Exports/ExportsDataFormattedTest.php
@@ -198,4 +198,30 @@ describe('ExportsData formatted export', function (): void {
 
         expect($exporter->testMapRow($row)['tags'])->toBe('first; second');
     });
+
+    test('mapRow exports a json object column as json instead of formatting its fields', function (): void {
+        $exporter = new ExportsDataTestClass(
+            ['commission_rate'],
+            ['commission_rate' => new PercentageFormatter()]
+        );
+
+        $row = new class() extends Model
+        {
+            protected $guarded = [];
+
+            public function __construct()
+            {
+                parent::__construct([
+                    'commission_rate' => [
+                        'id' => 5,
+                        'uuid' => '9b1c4f2e',
+                        'commission_rate' => 0.12,
+                    ],
+                ]);
+            }
+        };
+
+        expect($exporter->testMapRow($row)['commission_rate'])
+            ->toBe('{"id":5,"uuid":"9b1c4f2e","commission_rate":0.12}');
+    });
 });

--- a/tests/Unit/Formatters/PercentageFormatterTest.php
+++ b/tests/Unit/Formatters/PercentageFormatterTest.php
@@ -77,4 +77,16 @@ describe('PercentageFormatter', function (): void {
 
         expect($formatter->format(75))->toBe('75 %');
     });
+
+    it('returns empty string for a value that is not a number', function (): void {
+        $formatter = new PercentageFormatter();
+
+        expect($formatter->format('9b1c-4f2e-not-a-number'))->toBe('');
+    });
+
+    it('returns empty string for an array value', function (): void {
+        $formatter = new PercentageFormatter();
+
+        expect($formatter->format(['id' => 5, 'commission_rate' => 0.12]))->toBe('');
+    });
 });


### PR DESCRIPTION
## Problem

Production error on an export (Flare `9243530`): `ValueError bcmul(): Argument #1 ($num1) is not well-formed`, `PercentageFormatter:20` via `ExportsData:121`.

A column can resolve to an associative array. Two ways this happens:

- a json column cast to `array` — e.g. a frozen snapshot of a rate;
- a loaded relation whose snake_case name equals a real column name. `Model::toArray()` merges `relationsToArray()` over `attributesToArray()`, so the relation record replaces the column value under the same key.

v2.6.14 started formatting array values element by element. That is correct for a list coming from a to-many relation, but for an object it handed every field to the column formatter on its own, so a `PercentageFormatter` received an id and a uuid and `bcmul` raised.

The list path never hits this because the value gets flattened in `augmentItemArray()`, which the export path does not call.

## Change

- `ExportsData::formatExportValue()` treats a non-list array as one structured value and exports it as json. Field names survive, which a scalar formatter would drop. Element-wise formatting is unchanged for list arrays.
- `PercentageFormatter` guards its input the way `MoneyFormatter` already does and returns an empty string for anything that is not a number. This closes the same `ValueError` for every other path into the formatter, the list rendering included.

## Not done: running `augmentItemArray()` in the export path

Making the export call the hook would fix the value here, but measured against the 16 implementations in flux-core it is not safe as a general rule:

- over half do per-row IO — `morphTo(...)->getResults()` per row, `hasGeneratedConversion()` filesystem checks, avatar URL generation. Acceptable for one page of 25 rows, an outage for an export that runs over the whole filtered result set;
- several produce exactly what must not land in a file — a raw HTML `<div>` used for indentation, signed media URLs;
- two apply `Str::limit()`, which would silently truncate exported data.

An export-safe hook is a separate change, not a patch release.

## Tests

- `ExportsDataFormattedTest`: an object column with a `PercentageFormatter` exports as json. Red before the change with the production `ValueError`.
- `PercentageFormatterTest`: non-numeric and array input return an empty string.

Full suite green: 2270 passed, 1 skipped. Pint passes.