### PR TITLE
fix(data-table): let a column be dragged narrower than its content

### DIFF
--- a/resources/js/components/data-table.js
+++ b/resources/js/components/data-table.js
@@ -91,18 +91,72 @@ export default function data_table() {
             return valueIndex === 0 ? val || '' : '';
         },
 
+        /**
+         * A column only obeys a width once the table itself has a definite one.
+         * While the table stays at `width: auto` the fixed layout keeps sizing
+         * on content, so a width set on a cell can widen a column and never
+         * narrow it. Every column therefore carries a width here and the table
+         * carries their sum.
+         */
+        applyColWidths(table, freezeAll = false) {
+            const stored = this.$wire.colWidths || {};
+            const ths = [
+                ...table.querySelectorAll('thead > tr:first-child > th'),
+            ];
+
+            if (ths.length === 0) {
+                return;
+            }
+
+            // Measuring runs on the automatic layout and with no width in the
+            // way: a stored width narrower than the column content reads back
+            // as the content width there, and that is the one number that must
+            // not be frozen.
+            table.classList.remove('table-fixed');
+            table.classList.add('table-auto');
+            table.style.width = '';
+            ths.forEach((th) => (th.style.width = ''));
+
+            if (!freezeAll && Object.keys(stored).length === 0) {
+                return;
+            }
+
+            const widths = ths.map(
+                (th) => stored[th.dataset.column] ?? th.offsetWidth,
+            );
+
+            ths.forEach((th, i) => (th.style.width = widths[i] + 'px'));
+            table.style.width =
+                widths.reduce((sum, width) => sum + width, 0) + 'px';
+            table.classList.remove('table-auto');
+            table.classList.add('table-fixed');
+        },
+
+        syncColWidths(table) {
+            // Reading both is what subscribes the effect to them. The layout
+            // work itself waits a tick, because on the first run the column
+            // cells still have to come out of the x-for above them.
+            void this.$wire.colWidths;
+            void this.$wire.enabledCols;
+
+            this.$nextTick(() => this.applyColWidths(table));
+        },
+
         startResize(event, col) {
             event.preventDefault();
             event.stopPropagation();
 
             const th = event.target.closest('th');
-            const startX = event.clientX;
-            const startWidth = th.offsetWidth;
             const table = th.closest('table');
             const wire = this.$wire;
 
-            table.classList.remove('table-auto');
-            table.classList.add('table-fixed');
+            // Nothing is pinned before the first drag, so the table is still
+            // sized by its content and would ignore a drag to the left.
+            this.applyColWidths(table, true);
+
+            const startX = event.clientX;
+            const startWidth = th.offsetWidth;
+            const startTableWidth = table.offsetWidth;
 
             const onMouseMove = (e) => {
                 const newWidth = Math.max(
@@ -110,6 +164,10 @@ export default function data_table() {
                     startWidth + (e.clientX - startX),
                 );
                 th.style.width = newWidth + 'px';
+                // The table follows, or the column takes its room from a
+                // neighbour instead of from the table's own width.
+                table.style.width =
+                    startTableWidth + (newWidth - startWidth) + 'px';
             };
 
             const onMouseUp = () => {
@@ -118,18 +176,23 @@ export default function data_table() {
                 document.body.style.cursor = '';
                 document.body.style.userSelect = '';
 
+                // Read back off the cells themselves. Counting past the
+                // columns in front of the data went wrong as soon as a search
+                // added the relevance column and every width landed one column
+                // over.
                 const colWidths = {};
-                const cols = wire.enabledCols || [];
-                const ths = table.querySelectorAll(
-                    'thead > tr:first-child > th',
-                );
-                const offset = 1;
-                cols.forEach((c, i) => {
-                    const t = ths[i + offset];
-                    if (t && t.style.width) {
-                        colWidths[c] = parseInt(t.style.width, 10);
-                    }
-                });
+                table
+                    .querySelectorAll(
+                        'thead > tr:first-child > th[data-column]',
+                    )
+                    .forEach((t) => {
+                        if (t.style.width) {
+                            colWidths[t.dataset.column] = parseInt(
+                                t.style.width,
+                                10,
+                            );
+                        }
+                    });
 
                 if (Object.keys(colWidths).length > 0) {
                     wire.colWidths = colWidths;
@@ -154,18 +217,21 @@ export default function data_table() {
             );
 
             this._disposers.push(
-                this.$watch('$wire.broadcastChannels', (newChannels, oldChannels) => {
-                    const newValues = Object.values(newChannels || {});
-                    const oldValues = Object.values(oldChannels || {});
+                this.$watch(
+                    '$wire.broadcastChannels',
+                    (newChannels, oldChannels) => {
+                        const newValues = Object.values(newChannels || {});
+                        const oldValues = Object.values(oldChannels || {});
 
-                    oldValues
-                        .filter((ch) => !newValues.includes(ch))
-                        .forEach((ch) => this._leaveChannel(ch));
+                        oldValues
+                            .filter((ch) => !newValues.includes(ch))
+                            .forEach((ch) => this._leaveChannel(ch));
 
-                    newValues
-                        .filter((ch) => !oldValues.includes(ch))
-                        .forEach((ch) => this._subscribeChannel(ch));
-                }),
+                        newValues
+                            .filter((ch) => !oldValues.includes(ch))
+                            .forEach((ch) => this._subscribeChannel(ch));
+                    },
+                ),
             );
         },
 
@@ -193,9 +259,7 @@ export default function data_table() {
                 return;
             }
 
-            this._echoChannels.forEach((channel) =>
-                window.Echo.leave(channel),
-            );
+            this._echoChannels.forEach((channel) => window.Echo.leave(channel));
             this._echoChannels = [];
         },
     };

--- a/resources/views/components/layouts/table.blade.php
+++ b/resources/views/components/layouts/table.blade.php
@@ -25,7 +25,7 @@
 >
     <div class="relative overflow-x-auto shadow-sm sm:rounded-lg">
         <table class="dark:bg-secondary-800 min-w-full border-collapse bg-white text-sm text-gray-500 dark:text-gray-50"
-            x-bind:class="Object.keys($wire.colWidths || {}).length > 0 ? 'table-fixed' : 'table-auto'"
+            x-effect="syncColWidths($el)"
         >
             @php
                 $hasRelevance = collect($this->data['data'] ?? [])->contains(fn ($r) => isset($r['_relevance']));
@@ -80,7 +80,8 @@
                             <x-tall-datatables::table.head-cell
                                 :wrap="$this::$wrapColumnLabels"
                                 x-bind:class="{!! $headColClass !!}"
-                                x-bind:style="[($wire.stickyCols || []).includes(col) ? 'z-index: 2' : 'z-index: 1', ($wire.colWidths || {})[col] ? 'width: ' + ($wire.colWidths || {})[col] + 'px' : ''].filter(Boolean).join('; ')"
+                                x-bind:data-column="col"
+                                x-bind:style="($wire.stickyCols || []).includes(col) ? 'z-index: 2' : 'z-index: 1'"
                                 :attributes="$tableHeadColAttributes"
                             >
                                 <div class="group flex items-center gap-1">

--- a/tests/Browser/ShrinkColumnBrowserTest.php
+++ b/tests/Browser/ShrinkColumnBrowserTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * A column has to get narrower, not only wider.
+ *
+ * The fixed layout only decides a column's width once the table itself has a
+ * definite one. While the table stays at `width: auto` the browser keeps
+ * sizing on content, a width set on the cell reads as a wish and the content
+ * overrules it from below. A column then stops at whatever its widest cell
+ * needs and dragging to the left does nothing at all, which is the one
+ * direction that matters on a table already too wide for the screen.
+ */
+
+use Tests\Fixtures\Livewire\ResizablePostDataTable;
+
+beforeEach(function (): void {
+    $manifestPath = dirname(__DIR__, 2) . '/dist/build/manifest.json';
+    if (! file_exists($manifestPath)) {
+        $this->markTestSkipped('Browser tests require built assets. Run: npm run build');
+    }
+
+    $this->user = createTestUser(['name' => 'Test User', 'email' => 'shrink@example.com']);
+
+    for ($i = 1; $i <= 5; $i++) {
+        createTestPost([
+            'user_id' => $this->user->getKey(),
+            'title' => "A Rather Long Post Title {$i}",
+            'content' => "Content {$i}",
+            'is_published' => true,
+        ]);
+    }
+});
+
+it('drags a column below the width of its own content', function (): void {
+    $page = visitLivewire(ResizablePostDataTable::class);
+
+    $page->wait(2);
+
+    $result = $page->script('() => {
+        return new Promise((resolve) => {
+            const handle = document.querySelectorAll(".cursor-col-resize")[0];
+            if (! handle) return resolve({ error: "no handle" });
+
+            const th = handle.closest("th");
+            const rect = handle.getBoundingClientRect();
+            const x = rect.left + rect.width / 2;
+            const y = rect.top + rect.height / 2;
+            const natural = th.offsetWidth;
+            const distance = 60 - natural;
+
+            handle.dispatchEvent(new MouseEvent("mousedown", { clientX: x, clientY: y, bubbles: true }));
+            document.dispatchEvent(new MouseEvent("mousemove", { clientX: x + distance, clientY: y, bubbles: true }));
+            document.dispatchEvent(new MouseEvent("mouseup", { clientX: x + distance, clientY: y, bubbles: true }));
+
+            setTimeout(() => resolve({
+                natural,
+                requested: parseInt(th.style.width, 10) || 0,
+                rendered: th.offsetWidth,
+            }), 500);
+        });
+    }');
+
+    $data = is_array($result) && isset($result[0]) ? $result[0] : $result;
+
+    // The column has to be wider than the target to begin with, otherwise the
+    // drag proves nothing.
+    expect($data['natural'])->toBeGreaterThan(80)
+        ->and($data['requested'])->toBe(60)
+        ->and($data['rendered'])->toBeLessThanOrEqual(65);
+});


### PR DESCRIPTION
## The bug

A column could be widened and never narrowed. Dragging to the left stopped at the column's natural width — a different floor per column — and setting a width directly on the cell behaved exactly the same.

Measured on a table with an 18 column head:

| table `width` | width set on the cell | rendered |
|---|---|---|
| `auto` (before) | 100px | 241px |
| `auto`, `table-layout: auto` | 100px | 241px |
| `100%` | 100px | 100px |
| `1200px` | 100px | 100px |
| `max-content` | 60px | 241px |

The table carries `min-w-full` but no `width`. With `width: auto` the fixed layout keeps sizing on content, so a width on a cell reads as a wish the content overrules from below. The `table-fixed` class was switched on and did nothing, which is why the automatic and the fixed layout were indistinguishable in every test. On a table already too wide for the screen this removed the one direction that helps.

## The fix

The first drag measures every column, writes those widths onto the cells and gives the table their sum. The layout then has a definite width to divide and a column follows the drag in both directions. The table width tracks the drag as well, otherwise the room a column gives up is taken by its neighbour instead of by the table.

Widths are re-applied through `syncColWidths`, which reads the stored widths and the enabled columns so the effect re-runs when either changes, and defers the layout work by a tick because the column cells come from an `x-for` that has not rendered on the first pass.

## Also in here

Stored widths are read back off the cells themselves through `data-column` instead of counting past a fixed number of columns in front of the data. That count assumed one, while the head row grows a relevance column as soon as a search returns scores, and from then on every stored width landed one column over.

## Test

`tests/Browser/ShrinkColumnBrowserTest.php` drags a column to 60px and asserts what the browser actually renders. It fails on `main` with `192`, the column's natural width. The existing minimum-width test only looked at `style.width`, never at the rendered width, which is how this passed for so long.

Full suite green: 2271 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5J41UKr5nGRAQBzfde6QU